### PR TITLE
feat: GitHub Actions CD로 EC2 백엔드 자동 배포 구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
-# Re-Verse CD 워크플로우 (추후 작성)
-# main 브랜치 push 시 Docker 빌드 & 배포 예정
+# Re-Verse CD: main 브랜치 push 시 EC2 백엔드 자동 배포
+# 프론트엔드는 Vercel GitHub 연동으로 별도 자동 배포
 
-name: Re-Verse CD
+name: Deploy to EC2
 
 on:
   push:
@@ -9,8 +9,26 @@ on:
   workflow_dispatch:
 
 jobs:
-  placeholder:
-    name: CD (작성 예정)
+  deploy:
+    name: EC2 백엔드 배포
     runs-on: ubuntu-latest
     steps:
-      - run: echo "CD 워크플로우 준비 중"
+      - name: EC2 접속 후 최신 코드 배포
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            set -e
+            if [ ! -d "Re-Verse" ]; then
+              git clone https://github.com/upstage-sesac-final-project/Re-Verse.git
+            fi
+            cd Re-Verse
+            git fetch origin main
+            git reset --hard origin/main
+
+            echo "${{ secrets.ENV_FILE }}" > .env
+
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+            docker image prune -f

--- a/README-DEPLOYMENT.md
+++ b/README-DEPLOYMENT.md
@@ -24,7 +24,49 @@ Supabase/External APIs (데이터베이스 & AI 서비스)
 
 ---
 
-## 🛠 1단계: EC2 백엔드 배포
+## 🔄 GitHub Actions CD (자동 배포)
+
+`main` 브랜치에 push하거나 PR을 merge하면 **EC2 백엔드가 자동으로 재배포**됩니다.
+
+### 동작 방식
+
+1. **트리거**: `main`에 push 또는 Actions에서 "Run workflow" 수동 실행
+2. **실행**: GitHub Actions가 EC2에 SSH로 접속
+3. **EC2에서**: `Re-Verse` 폴더로 이동 → `git fetch` / `git reset`으로 최신 main 반영 → `.env` 생성 → `docker compose` 빌드 및 재시작 → 사용하지 않는 이미지 정리
+
+### 필요한 GitHub 시크릿 (Repository secrets)
+
+| 시크릿 이름 | 설명 |
+|-------------|------|
+| `EC2_HOST` | EC2 인스턴스 IP 또는 호스트명 |
+| `EC2_USERNAME` | SSH 사용자 (예: `ubuntu`, `ec2-user`) |
+| `EC2_SSH_KEY` | EC2 접속용 비공개 키 전체 내용 |
+| `ENV_FILE` | EC2에서 쓸 `.env` 파일 내용 전체 (한 덩어리로 붙여넣기) |
+
+### 사용법
+
+**자동 실행 (권장)**
+- `main`에 직접 push하거나, PR을 `main`으로 merge하면 워크플로가 자동 실행됩니다.
+
+**수동 실행**
+1. GitHub 저장소 → **Actions** 탭
+2. 왼쪽에서 **Deploy to EC2** 선택
+3. **Run workflow** → **Run workflow** 클릭
+
+**배포 결과 확인**
+- Actions 탭에서 해당 워크플로 실행 클릭 → 각 step 로그 확인
+- EC2에서: `docker compose -f docker-compose.yml -f docker-compose.prod.yml ps` 로 컨테이너 상태 확인
+
+### EC2 사전 준비 (최초 1회)
+
+- SSH 접속 가능 (22번 포트 열기)
+- Docker, Docker Compose 설치 완료
+- SSH 사용자에게 `docker` 그룹 권한 부여 (`sudo usermod -a -G docker $USER`)
+- **Private 리포인 경우**: EC2에 Deploy Key 등록 후 `git clone` 가능한 경로에서 사용하거나, 스크립트 내 `git clone` URL을 토큰 포함 URL로 변경
+
+---
+
+## 🛠 1단계: EC2 백엔드 배포 (수동)
 
 ### EC2 인스턴스 준비
 ```bash


### PR DESCRIPTION
## 🚀 GitHub Actions 기반 백엔드(EC2) 자동 배포(CD) 파이프라인 구축

### 🛠 작업 내용

#### **CI/CD 파이프라인 설계 및 구축**
- **투트랙 배포 자동화**: 프론트엔드는 Vercel(GitHub 연동)로 자동 배포되고, 백엔드는 GitHub Actions를 통해 EC2로 자동 배포되도록 인프라 분리 완료
- **SSH 원격 접속 자동화**: `appleboy/ssh-action`을 활용하여 GitHub 로봇이 안전하게 EC2에 원격 접속하여 배포 스크립트를 실행하도록 구성
- **보안 및 환경변수 격리**: GitHub Secrets(`ENV_FILE`)를 활용하여 배포 시점에 EC2 내부에 `.env` 파일을 동적으로 자동 생성하여 보안 강화

---

### 💡 주요 변경 사항

- **강제 동기화 배포**: 충돌 방지를 위해 `git fetch` + `git reset --hard origin/main`을 사용하여 EC2 서버의 코드를 항상 깃허브 최신 상태로 유지하도록 설정
- **무중단 재시작 및 최적화**: `docker compose up -d --build` 실행 후, `docker image prune -f`를 통해 불필요한 이전 Docker 이미지를 자동 청소하여 서버 용량 지속 확보
- **수동 배포 지원**: `workflow_dispatch` 옵션을 추가하여, 필요시 GitHub Actions 탭에서 버튼 클릭만으로 수동 배포가 가능하도록 지원
- **문서화 업데이트**: `README-DEPLOYMENT.md`에 CD 파이프라인 동작 원리 및 시크릿 키 세팅 방법 추가

---

### 📁 관련 파일

| 파일명 | 역할 |
|--------|------|
| `.github/workflows/deploy.yml` | EC2 CD 워크플로우 핵심 스크립트 (트리거 조건, SSH 접속, Docker 실행) |
| `README-DEPLOYMENT.md` | CD 아키텍처 설명, 필수 GitHub Secrets 목록 및 배포 가이드 업데이트 |

---

### ✅ Test Plan

- [x] `main` 브랜치 Push 시 GitHub Actions 트리거 정상 작동 확인
- [x] GitHub Secrets(`EC2_HOST`, `EC2_USERNAME`, `EC2_SSH_KEY`)를 통한 SSH 원격 접속 성공
- [x] `ENV_FILE` 시크릿을 통한 EC2 내부 `.env` 파일 자동 생성 및 포맷 검증