### PR TITLE
feat: Vercel 빌드 설정 간소화

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,11 @@
 {
+  "installCommand": "cd app/frontend && npm install",
+  "buildCommand": "cd app/frontend && npm run build",
   "outputDirectory": "app/frontend/dist",
-  "framework": "vite",
-  "devCommand": "cd app/frontend && npm run dev",
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "http://44.215.113.101:8000/api/:path*"
+      "destination": "http://34.226.65.141:8000/api/:path*"
     }
   ],
   "env": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,11 @@
 {
-  "buildCommand": "cd app/frontend && npm run build",
   "outputDirectory": "app/frontend/dist",
   "framework": "vite",
-  "installCommand": "cd app/frontend && npm install",
   "devCommand": "cd app/frontend && npm run dev",
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "http://YOUR-EC2-IP:8000/api/:path*"
+      "destination": "http://44.215.113.101:8000/api/:path*"
     }
   ],
   "env": {


### PR DESCRIPTION
vercel.json에서 buildCommand, installCommand 제거하여 Vercel 기본 빌드/설치 흐름 사용 프론트엔드 빌드 파이프라인을 Vercel 표준에 맞게 정리하여 설정 중복/혼란 방지
관련 파일:

vercel.json: buildCommand, installCommand 키 제거 및 기본 설정 위임