### PR TITLE
feat: planner 프롬프트 작성, planner 노드 및 테스트 코드 구현

### DIFF
--- a/agent/graph/nodes/planner.py
+++ b/agent/graph/nodes/planner.py
@@ -1,17 +1,79 @@
 """Planner 노드 — 3단계: 수정 시나리오 계획 수립.
 
 담당: 화진님
+
+역할:
+    Definition이 추출한 수정 내용을 받아, RPG Maker MZ 파일 구조 지식을 기반으로
+    실행 순서가 있는 자연어 단계 계획(execution_plan)을 수립한다.
+    파일에는 접근하지 않는다.
+
+입력 (state):
+    user_input, intent, modifications, extracted_ids, target_files
+
+출력 (state):
+    execution_plan: list[dict]
 """
 
 import logging
+from typing import Literal, cast
 
-from agent.core.llm_client import invoke_llm  # noqa: F401
+from pydantic import BaseModel, Field
+
+from agent.core.llm_client import invoke_llm
 from agent.graph.state import AgentState
-from agent.prompts.planner_prompt import build_prompt  # noqa: F401
+from agent.prompts.planner_prompt import build_prompt
 
 logger = logging.getLogger(__name__)
 
 
+class _ExecutionStep(BaseModel):
+    step_id: int = Field(description="단계 번호 (1부터 시작)")
+    description: str = Field(description="executor가 읽을 자연어 실행 지침")
+    action_type: Literal["query", "create", "update", "delete"] = Field(description="실행 유형")
+    target_file: str = Field(description="대상 JSON 파일명 (예: Skills.json)")
+    target_info: dict = Field(description="이 step에서 다룰 데이터 명세")
+    depends_on: list[int] = Field(
+        default_factory=list,
+        description="선행 step_id 목록. 빈 리스트면 즉시 실행",
+    )
+    condition: str = Field(
+        default="",
+        description="실행 조건. 없으면 빈 문자열",
+    )
+
+
+class _PlannerOutput(BaseModel):
+    execution_plan: list[_ExecutionStep] = Field(description="순서 있는 실행 단계 목록")
+    reasoning: str = Field(description="계획 수립 근거 (로깅용)")
+
+
 async def planner(state: AgentState) -> dict:
-    # TODO: 구현 필요
-    raise NotImplementedError
+    """Definition 결과를 받아 실행 계획을 수립한다.
+
+    Args:
+        state: 현재 AgentState.
+
+    Returns:
+        execution_plan 을 담은 dict.
+    """
+    logger.info(
+        "Planner 시작 | intent=%s | target_files=%s",
+        state.get("intent"),
+        state.get("target_files"),
+    )
+
+    messages = build_prompt(state)
+
+    try:
+        result = cast(_PlannerOutput, await invoke_llm(messages, structured_output=_PlannerOutput))
+        execution_plan = [step.model_dump() for step in result.execution_plan]
+        logger.info(
+            "Planner 완료 | steps=%d | reasoning=%s",
+            len(execution_plan),
+            result.reasoning,
+        )
+    except Exception as e:
+        logger.error("Planner LLM 호출 실패: %s", e)
+        execution_plan = []
+
+    return {"execution_plan": execution_plan}

--- a/agent/prompts/planner_prompt.py
+++ b/agent/prompts/planner_prompt.py
@@ -1,13 +1,137 @@
-"""TODO: 프롬프트 구현
+"""Planner 프롬프트 — RPG Maker MZ 파일 구조 지식 기반 실행 계획 수립.
 
 담당 : 화진님
 """
 
-from langchain_core.messages import BaseMessage
+import json
+
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
 from agent.graph.state import AgentState
 
+_SYSTEM_PROMPT = """\
+당신은 RPG Maker MZ 게임 수정 작업의 실행 계획을 수립하는 에이전트입니다.
+사용자의 요청과 Definition 분석 결과를 받아, 어떤 파일을 어떤 순서로 수정해야 하는지
+단계별 실행 계획(execution_plan)을 만드는 것이 목표입니다.
+
+파일에 직접 접근하지 않습니다. 아래의 파일 구조 지식만을 바탕으로 계획을 수립하세요.
+
+---
+
+## RPG Maker MZ 파일 구조
+
+### 파일별 역할 및 참조 필드
+
+모든 참조는 **id 값이 아닌 배열 인덱스** 기준이다. 새 항목 추가 시 빈 슬롯(name="") 인덱스를 재사용하거나 배열 끝에 append하며, index 0은 항상 null이다.
+
+| 파일 | 역할 | 참조 필드 → 대상 파일 |
+|------|------|----------------------|
+| Actors.json | 플레이어 캐릭터 | classId→Classes, equips[]→Weapons/Armors, traits[] |
+| Classes.json | 직업 | learnings[].skillId→Skills, traits[] |
+| Skills.json | 스킬 | stypeId→System.skillTypes, damage.elementId→System.elements, effects[code=21].dataId→States, requiredWtypeId1→System.weaponTypes, requiredWtypeId2→System.weaponTypes, animationId→Animations |
+| Items.json | 아이템 | damage.elementId→System.elements, animationId→Animations |
+| Weapons.json | 무기 | wtypeId→System.weaponTypes, etypeId→System.equipTypes(고정=1), animationId→Animations, traits[] |
+| Armors.json | 방어구 | atypeId→System.armorTypes, etypeId→System.equipTypes(2~5), traits[] |
+| Enemies.json | 적 | actions[].skillId→Skills, dropItems[kind=1].dataId→Items, dropItems[kind=2].dataId→Weapons, dropItems[kind=3].dataId→Armors, traits[] |
+| Troops.json | 적 군단 | members[].enemyId→Enemies |
+| System.json | 전역 설정 | partyMembers[]→Actors, testBattlers[].actorId→Actors, testBattlers[].equips[]→Weapons/Armors, testTroopId→Troops |
+
+### traits[] 코드 참조 (Actors·Classes·Enemies·Weapons·Armors 공통)
+
+| code | 참조 대상 | 의미 |
+|------|-----------|------|
+| 11 | System.elements | 속성 유효율 |
+| 13 | States | 상태 유효율 |
+| 31 | System.elements | 공격 시 속성 부여 |
+| 51 | System.weaponTypes | 장착 가능 무기 유형 |
+| 52 | System.armorTypes | 장착 가능 방어구 유형 |
+
+---
+
+## 계획 수립 지침
+
+1. 각 step은 단일 원자 작업으로 쪼갤 것
+2. 존재 여부가 불확실한 대상은 반드시 query step을 먼저 배치할 것
+3. condition 필드로 조건부 실행을 표현할 것
+   - 예) "step 1에서 파이어볼 스킬이 존재하지 않을 경우"
+   - 조건 없이 무조건 실행하는 step은 빈 문자열("")로 설정
+4. depends_on으로 선행 step과의 순서 의존성을 명시할 것
+5. target_info에 modifications와 extracted_ids의 내용을 구체적으로 포함할 것
+6. action_type은 반드시 "query" / "create" / "update" / "delete" 중 하나만 사용할 것
+
+---
+
+## 출력 예시
+
+사용자 요청: "주인공에게 파이어볼 스킬을 추가해줘"
+
+{
+  "execution_plan": [
+    {
+      "step_id": 1,
+      "description": "Skills.json에서 '파이어볼' 스킬 존재 여부 조회",
+      "action_type": "query",
+      "target_file": "Skills.json",
+      "target_info": {"skill_name": "파이어볼"},
+      "depends_on": [],
+      "condition": ""
+    },
+    {
+      "step_id": 2,
+      "description": "파이어볼 스킬이 없으면 Skills.json 빈 슬롯에 신규 생성",
+      "action_type": "create",
+      "target_file": "Skills.json",
+      "target_info": {"skill_name": "파이어볼"},
+      "depends_on": [1],
+      "condition": "step 1에서 파이어볼 스킬이 존재하지 않을 경우"
+    },
+    {
+      "step_id": 3,
+      "description": "주인공(actor_id=1)의 Actors.json traits[]에 파이어볼 스킬 부여 (code=35, dataId=파이어볼 인덱스)",
+      "action_type": "update",
+      "target_file": "Actors.json",
+      "target_info": {"actor_id": 1, "skill_name": "파이어볼"},
+      "depends_on": [1, 2],
+      "condition": ""
+    }
+  ],
+  "reasoning": "스킬을 먼저 생성한 뒤, 직업 전체가 아닌 주인공 개인에게만 부여하므로 Actors.json traits[]에 직접 등록"
+}
+"""
+
 
 def build_prompt(state: AgentState) -> list[BaseMessage]:
-    # TODO: 구현 필요
-    return []
+    """Planner LLM 프롬프트를 생성한다.
+
+    Args:
+        state: 현재 AgentState.
+               user_input, intent, modifications, extracted_ids, target_files 를 사용.
+
+    Returns:
+        [SystemMessage, HumanMessage] 형태의 메시지 목록.
+    """
+    user_input = state.get("user_input", "")
+    intent = state.get("intent", "")
+    modifications = state.get("modifications", [])
+    extracted_ids = state.get("extracted_ids", {})
+    target_files = state.get("target_files", [])
+
+    human_content = f"""\
+[사용자 요청]
+{user_input}
+
+[의도 분류 결과]
+intent: {intent}
+
+[Definition 분석 결과]
+modifications: {json.dumps(modifications, ensure_ascii=False, indent=2)}
+extracted_ids: {json.dumps(extracted_ids, ensure_ascii=False, indent=2)}
+target_files: {json.dumps(target_files, ensure_ascii=False)}
+
+위 내용을 바탕으로 RPG Maker MZ 파일 구조에 맞는 실행 계획을 수립해주세요.
+"""
+
+    return [
+        SystemMessage(content=_SYSTEM_PROMPT),
+        HumanMessage(content=human_content),
+    ]

--- a/agent/tests/test_planner.py
+++ b/agent/tests/test_planner.py
@@ -1,0 +1,324 @@
+"""Planner 노드 테스트.
+
+[ 테스트 구조 ]
+  - 입력(state) : 하드코딩된 mock 데이터 (Definition이 넘겨줄 값을 직접 작성)
+  - LLM 호출   : 실제 API 호출 → .env의 LLM_API_KEY 필요
+  - 검증        : execution_plan의 구조 및 내용 확인
+
+[ 실행 방법 ]
+  # 결과 출력 없이 검증만
+  uv run pytest agent/tests/test_planner.py -v
+
+  # LLM이 실제로 만든 execution_plan 내용까지 출력
+  uv run pytest agent/tests/test_planner.py -v -s
+
+  # 특정 테스트 함수 실행
+  uv run pytest agent/tests/test_planner.py::test_planner_add_skill_to_actor -v -s
+
+주의:
+    실제 LLM API를 호출하므로 루트 .env에 LLM_API_KEY가 설정되어 있어야 합니다.
+"""
+
+import json
+from typing import Any, cast
+
+import pytest
+
+from agent.graph.nodes.planner import planner
+from agent.graph.state import AgentState
+
+# ──────────────────────────────────────────────────────────────
+# 공통 헬퍼
+# ──────────────────────────────────────────────────────────────
+
+VALID_ACTION_TYPES = {"query", "create", "update", "delete"}
+
+
+def build_state(
+    user_input: str,
+    intent: str,
+    modifications: list[dict],
+    extracted_ids: dict,
+    target_files: list[str],
+) -> AgentState:
+    """테스트용 AgentState를 생성한다.
+
+    다른 노드와 통합 테스트 시 이 함수로 초기 state를 구성해 재사용할 수 있다.
+    """
+    return AgentState(
+        user_input=user_input,
+        intent=cast(Any, intent),
+        modifications=modifications,
+        extracted_ids=extracted_ids,
+        target_files=target_files,
+    )
+
+
+def print_execution_plan(test_name: str, result: dict) -> None:
+    """LLM이 생성한 execution_plan을 읽기 좋게 출력한다.
+
+    pytest -s 옵션으로 실행할 때 실제 LLM 응답 내용을 확인할 수 있다.
+    """
+    plan = result.get("execution_plan", [])
+    print(f"\n{'=' * 60}")
+    print(f"[{test_name}] execution_plan ({len(plan)} steps)")
+    print("=" * 60)
+    for step in plan:
+        print(f"\n  step {step['step_id']} [{step['action_type'].upper()}] {step['target_file']}")
+        print(f"  설명     : {step['description']}")
+        print(f"  target_info: {json.dumps(step['target_info'], ensure_ascii=False)}")
+        print(f"  depends_on : {step['depends_on']}")
+        if step["condition"]:
+            print(f"  조건     : {step['condition']}")
+    print("=" * 60)
+
+
+def assert_execution_plan(result: dict, min_steps: int = 1) -> list[dict]:
+    """execution_plan 기본 구조를 검증하고 plan 리스트를 반환한다."""
+    assert "execution_plan" in result, "execution_plan 키가 없습니다"
+
+    plan = result["execution_plan"]
+    assert isinstance(plan, list), "execution_plan이 리스트가 아닙니다"
+    assert len(plan) >= min_steps, f"step이 {min_steps}개 이상이어야 합니다 (실제: {len(plan)})"
+
+    step_ids = []
+    for step in plan:
+        # 필수 필드 존재 여부
+        for field in (
+            "step_id",
+            "description",
+            "action_type",
+            "target_file",
+            "target_info",
+            "depends_on",
+            "condition",
+        ):
+            assert field in step, f"step에 '{field}' 필드가 없습니다: {step}"
+
+        # 타입 검증
+        assert isinstance(step["step_id"], int), "step_id가 int가 아닙니다"
+        assert isinstance(step["description"], str) and step["description"], (
+            "description이 비어 있습니다"
+        )
+        assert step["action_type"] in VALID_ACTION_TYPES, (
+            f"action_type이 유효하지 않습니다: {step['action_type']}"
+        )
+        assert isinstance(step["target_file"], str) and step["target_file"], (
+            "target_file이 비어 있습니다"
+        )
+        assert isinstance(step["target_info"], dict), "target_info가 dict가 아닙니다"
+        assert isinstance(step["depends_on"], list), "depends_on이 리스트가 아닙니다"
+        assert isinstance(step["condition"], str), "condition이 str가 아닙니다"
+
+        step_ids.append(step["step_id"])
+
+    # depends_on이 앞서 등장한 step_id만 참조하는지 검증
+    seen = set()
+    for step in plan:
+        for dep in step["depends_on"]:
+            assert dep in seen, (
+                f"step {step['step_id']}의 depends_on={dep}이 아직 등장하지 않은 step을 참조합니다"
+            )
+        seen.add(step["step_id"])
+
+    return plan
+
+
+# ──────────────────────────────────────────────────────────────
+# 테스트 케이스
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_planner_add_skill_to_actor1():
+    """액터에게 스킬 추가 — 가장 복잡한 관계 (Actors → Classes → Skills) 테스트."""
+    state = build_state(
+        user_input="쥔공에게 치즈 폭탄 추가해줘",
+        intent="game_modify",
+        modifications=[{"type": "add_skill", "target": "actor", "skill_name": "치즈 폭탄"}],
+        extracted_ids={"actor_id": 1},
+        target_files=["Actors.json", "Skills.json"],
+    )
+
+    result = await planner(state)
+    print_execution_plan("스킬 추가", result)
+    plan = assert_execution_plan(result, min_steps=2)
+
+    # Skills.json을 다루는 step이 반드시 포함되어야 함
+    target_files_in_plan = {step["target_file"] for step in plan}
+    assert "Skills.json" in target_files_in_plan, "Skills.json을 다루는 step이 없습니다"
+
+    # 스킬을 액터에 연결하는 update step이 있어야 함
+    # RPG Maker MZ에서 스킬 연결 경로는 두 가지:
+    #   1. Actors.json traits[] — 해당 액터 단독 부여
+    #   2. Classes.json learnings[] — 직업 전체에 스킬 학습 부여
+    skill_link_steps = [
+        s
+        for s in plan
+        if s["target_file"] in ("Actors.json", "Classes.json") and s["action_type"] == "update"
+    ]
+    assert skill_link_steps, (
+        "Actors.json 또는 Classes.json에 스킬을 연결하는 update step이 없습니다"
+    )
+
+    # Planner는 game_context를 채우지 않는다 (Executor 담당)
+    assert "game_context" not in result, (
+        "Planner는 game_context를 반환하지 않아야 합니다 (Executor 담당)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_planner_add_skill_to_actor2():
+    """액터에게 스킬 추가 — 가장 복잡한 관계 (Actors → Classes → Skills) 테스트."""
+    state = build_state(
+        user_input="주인공에게 파이어볼 스킬을 추가해줘",
+        intent="game_modify",
+        modifications=[{"type": "add_skill", "target": "actor", "skill_name": "파이어볼"}],
+        extracted_ids={"actor_id": 1},
+        target_files=["Actors.json", "Skills.json"],
+    )
+
+    result = await planner(state)
+    print_execution_plan("스킬 추가", result)
+    plan = assert_execution_plan(result, min_steps=2)
+
+    # Skills.json을 다루는 step이 반드시 포함되어야 함
+    target_files_in_plan = {step["target_file"] for step in plan}
+    assert "Skills.json" in target_files_in_plan, "Skills.json을 다루는 step이 없습니다"
+
+    # 스킬을 액터에 연결하는 update step이 있어야 함
+    # RPG Maker MZ에서 스킬 연결 경로는 두 가지:
+    #   1. Actors.json traits[] — 해당 액터 단독 부여
+    #   2. Classes.json learnings[] — 직업 전체에 스킬 학습 부여
+    skill_link_steps = [
+        s
+        for s in plan
+        if s["target_file"] in ("Actors.json", "Classes.json") and s["action_type"] == "update"
+    ]
+    assert skill_link_steps, (
+        "Actors.json 또는 Classes.json에 스킬을 연결하는 update step이 없습니다"
+    )
+
+
+@pytest.mark.asyncio
+async def test_planner_add_enemy():
+    """적(Enemy) 추가 — Enemies.json 단독 수정 테스트."""
+    state = build_state(
+        user_input="드래곤이라는 적을 추가해줘",
+        intent="game_modify",
+        modifications=[{"type": "add_enemy", "target": "enemy", "enemy_name": "드래곤"}],
+        extracted_ids={},
+        target_files=["Enemies.json"],
+    )
+
+    result = await planner(state)
+    print_execution_plan("적 추가", result)
+    plan = assert_execution_plan(result, min_steps=1)
+
+    # Enemies.json을 다루는 step이 반드시 포함되어야 함
+    enemy_steps = [s for s in plan if s["target_file"] == "Enemies.json"]
+    assert enemy_steps, "Enemies.json을 다루는 step이 없습니다"
+
+
+@pytest.mark.asyncio
+async def test_planner_add_npc_to_map():
+    """맵에 NPC 추가 — Map*.json events 수정 테스트."""
+    state = build_state(
+        user_input="1번 맵에 마을 촌장 NPC를 추가해줘",
+        intent="game_modify",
+        modifications=[{"type": "add_npc", "target": "map", "map_id": 1, "npc_name": "마을 촌장"}],
+        extracted_ids={"map_id": 1},
+        target_files=["Map001.json"],
+    )
+
+    result = await planner(state)
+    print_execution_plan("NPC 추가", result)
+    plan = assert_execution_plan(result, min_steps=1)
+
+    map_steps = [s for s in plan if "Map" in s["target_file"]]
+    assert map_steps, "Map 파일을 다루는 step이 없습니다"
+
+
+@pytest.mark.asyncio
+async def test_planner_add_item():
+    """아이템 추가 — Items.json 단독 수정 테스트."""
+    state = build_state(
+        user_input="불의 마법서라는 아이템을 추가해줘",
+        intent="game_modify",
+        modifications=[{"type": "add_item", "target": "item", "item_name": "불의 마법서"}],
+        extracted_ids={},
+        target_files=["Items.json"],
+    )
+
+    result = await planner(state)
+    print_execution_plan("아이템 추가", result)
+    plan = assert_execution_plan(result, min_steps=1)
+
+    item_steps = [s for s in plan if s["target_file"] == "Items.json"]
+    assert item_steps, "Items.json을 다루는 step이 없습니다"
+
+
+@pytest.mark.asyncio
+async def test_planner_modify_enemy_stat():
+    """기존 적 스탯 수정 — 존재 여부 query 후 update 순서 테스트."""
+    state = build_state(
+        user_input="슬라임의 HP를 500으로 올려줘",
+        intent="game_modify",
+        modifications=[
+            {
+                "type": "update_stat",
+                "target": "enemy",
+                "enemy_name": "슬라임",
+                "field": "hp",
+                "value": 500,
+            }
+        ],
+        extracted_ids={"enemy_name": "슬라임"},
+        target_files=["Enemies.json"],
+    )
+
+    result = await planner(state)
+    print_execution_plan("적 스탯 수정", result)
+    plan = assert_execution_plan(result, min_steps=1)
+
+    # query step이 update step보다 먼저 나와야 함
+    action_types_in_order = [s["action_type"] for s in plan]
+    if "query" in action_types_in_order and "update" in action_types_in_order:
+        assert action_types_in_order.index("query") < action_types_in_order.index("update"), (
+            "query step이 update step보다 먼저 나와야 합니다"
+        )
+
+
+@pytest.mark.asyncio
+async def test_planner_returns_no_game_context():
+    """Planner는 game_context를 채우지 않는다."""
+    state = build_state(
+        user_input="주인공에게 파이어볼 스킬을 추가해줘",
+        intent="game_modify",
+        modifications=[{"type": "add_skill", "target": "actor", "skill_name": "파이어볼"}],
+        extracted_ids={"actor_id": 1},
+        target_files=["Actors.json", "Skills.json"],
+    )
+
+    result = await planner(state)
+
+    assert "game_context" not in result, (
+        "Planner는 game_context를 반환하지 않아야 합니다 (Executor 담당)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_planner_step_dependency_order():
+    """depends_on이 항상 선행 step만 참조하는지 검증."""
+    state = build_state(
+        user_input="주인공에게 아이스 볼트 스킬을 추가해줘",
+        intent="game_modify",
+        modifications=[{"type": "add_skill", "target": "actor", "skill_name": "아이스 볼트"}],
+        extracted_ids={"actor_id": 1},
+        target_files=["Actors.json", "Skills.json"],
+    )
+
+    result = await planner(state)
+    print_execution_plan("의존성 순서 검증", result)
+    # assert_execution_plan 내부에서 depends_on 순서 검증이 포함됨
+    assert_execution_plan(result, min_steps=1)


### PR DESCRIPTION
Agent : planner node 구현

작업 내용

- 계획 노드 프롬프트
  - agent/prompts/planner_prompt.py 
    - LLM에게 전달할 전체 프롬프트 작성 (system prompt + human_content + definition result)
    - RPG maker MZ 프로젝트 파일의 역할 및 참조 필드를 참고하여 실행 계획 수립
    - depends_on, condition를 통해 선행 step과 조건부 실행 여부 기재
    - target_info 내 modifications과 extracted_ids 정보 포함하여 전달
    - action_type을 통해 특정 step에서 executor node의 필요 행동 정의 (query, create, update, delete)

- 계획 노드
  - agent/graph/nodes/planner.py 
    - pydantic의 BaseModel을 통한 응답 형식 제한(ExecutionStep, PlannerOutput)
    - LLM 호출 코드 (difinition 노드 결과, user input, 시스템 프롬프트 포함)

- 계획 노드 테스트 (실제 LLM 호출, API 키 필요)
  - agent/tests/test_planner.py
    - test_planner 파일에 기재된 테스트 케이스 통과
    - 그 외 100가지 추가 테스트 케이스 확인 (Actors, Classes, Enemies, Items, Skills 등 생성/수정)
      → 여러 파일이 참조 및 수정되는 경우 계획 순서 상 문제가 있는 테스트 케이스도 존재
          단, 기본 수정의 경우 대체적으로 올바른 방향으로 계획하는 것으로 확인

  - 테스트 실행 명령어
    - 테스트 실행 (계획 X) : uv run pytest agent/tests/test_planner.py -v 
    - 테스트 실행 (계획 O) : uv run pytest agent/tests/test_planner.py -v -s
    - 특정 함수만 실행 : uv run pytest agent/tests/test_planner.py::[테스트 함수명] -v -s