### PR TITLE
feat : execution_plan 기반 Executor 확장 + Classes/Actors/System update 흐름 MVP 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ storage/games/**/backup/*.bak
 
 # 게임 데이터 특정 파일 무시
 storage/games/*/data/*.json
+
+# 게임 데이터 전체 무시
+storage/games/

--- a/agent/graph/nodes/executor.py
+++ b/agent/graph/nodes/executor.py
@@ -33,7 +33,9 @@ from app.backend.services.json_modify_tools.dispatcher import (
     run_skills,
 )
 from app.backend.services.json_modify_tools.managers.actor_manager import ActorManager
+from app.backend.services.json_modify_tools.managers.class_manager import ClassManager
 from app.backend.services.json_modify_tools.managers.skill_manager import SkillManager
+from app.backend.services.json_modify_tools.managers.system_manager import SystemManager
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +62,13 @@ TARGET_FILE_MAP = {
 
 
 def _is_structured_execution_plan(plan: list[dict]) -> bool:
-    """3단계 Planner가 action_type / step_id / target_file 형태로 넘긴 플랜인지 판별."""
+    """3단계 Planner가 만든 "구조화 실행 플랜"인지 판별한다.
+
+    기대 포맷(필수 키):
+      - `step_id`
+      - `action_type` (query/create/update 등)
+      - `target_file` (예: `Actors.json`, `Classes.json`, `System.json`)
+    """
     if not plan or not isinstance(plan[0], dict):
         return False
     row = plan[0]
@@ -68,6 +76,7 @@ def _is_structured_execution_plan(plan: list[dict]) -> bool:
 
 
 def _collect_structured_target_files(execution_plan: list[dict]) -> set[str]:
+    """구조화 플랜에 등장한 JSON 파일들을 추려서 snapshot/backup 범위를 결정한다."""
     files: set[str] = set()
     for step in execution_plan:
         if not isinstance(step, dict):
@@ -79,7 +88,11 @@ def _collect_structured_target_files(execution_plan: list[dict]) -> set[str]:
 
 
 def _topological_sort_steps(execution_plan: list[dict]) -> list[dict]:
-    """depends_on(step_id) 기준 위상 정렬. 실패 시 step_id 오름차순 폴백."""
+    """depends_on(step_id) 기준 위상 정렬.
+
+    - 정상: 의존 step이 먼저 실행되게 순서를 만든다.
+    - 비정상(순환/누락): 완전 보장은 못하지만 step_id 오름차순으로 폴백한다.
+    """
     by_id: dict[int, dict] = {}
     for step in execution_plan:
         if not isinstance(step, dict) or "step_id" not in step:
@@ -127,7 +140,13 @@ def _topological_sort_steps(execution_plan: list[dict]) -> list[dict]:
 
 
 def _should_execute_structured_step(step: dict, step_results: dict[int, dict]) -> tuple[bool, str]:
-    """조건부 create(이미 존재 시 스킵) 등."""
+    """조건부로 step 실행/스킵을 결정한다.
+
+    MVP에서는 아래 휴리스틱을 적용한다.
+    - `depends_on` 결과가 없거나(누락), 의존 step이 실패하면 현재 step은 실행하지 않는다.
+    - `action_type == "create"`이고 `condition`에 "존재하지 않/없을 경우..." 같은 문구가 있으면
+      이전 `query` 결과의 `exists`를 보고 create를 스킵한다.
+    """
     try:
         # step_id 파싱이 실패하면(형식 이상) 안전하게 실행 여부를 기본값으로 반환
         int(step.get("step_id", -1))
@@ -149,11 +168,11 @@ def _should_execute_structured_step(step: dict, step_results: dict[int, dict]) -
     action = (step.get("action_type") or "").strip().lower()
     condition = (step.get("condition") or "").strip()
 
-    if action == "create" and dep_ids:
+    if action in {"create", "update", "delete"} and dep_ids:
         for did in dep_ids:
             prev = step_results[did]
             if not prev.get("skipped") and prev.get("success") is False:
-                return False, f"의존 step {did} 실패로 create 불가"
+                return False, f"의존 step {did} 실패로 {action} 불가"
 
     if action == "create" and condition:
         cond_create = any(k in condition for k in ("존재하지 않", "없을 경우", "없으면", "없을 때"))
@@ -175,7 +194,12 @@ async def _execute_one_structured_step(
     data_path: Path,
     step_results: dict[int, dict],
 ) -> dict[str, Any]:
-    """단일 구조화 스텝 실행 후 changes_log 항목(dict) 반환. step_results 갱신."""
+    """단일 구조화 step 실행(4단계).
+
+    - 입력: Planner가 만든 한 step(=action_type + target_file + target_info)
+    - 처리: 해당 조합을 "매니저(Actor/Class/System)" 호출로 디스패치
+    - 출력: `changes_log`에 들어갈 step 결과 + `step_results` 누적
+    """
     sid = int(step["step_id"])
     action = (step.get("action_type") or "").strip().lower()
     target_file = (step.get("target_file") or "").strip()
@@ -183,6 +207,38 @@ async def _execute_one_structured_step(
     ts = datetime.now().isoformat()
 
     try:
+        # target_file/action_type 조합을 현재 MVP에서 지원하는 매니저 호출로 매핑한다.
+        if target_file == "Classes.json" and action == "query":
+            mgr = ClassManager(data_path, f"struct_{sid}")
+            r = await mgr.execute("query", target_info=target_info)
+            step_results[sid] = {**r, "step_id": sid}
+            return {
+                "step_id": sid,
+                "tool_name": "structured_classes_query",
+                "success": bool(r.get("success")),
+                "stdout": r.get("message", ""),
+                "stderr": r.get("error") or "",
+                "exists": r.get("exists"),
+                "class_id": r.get("class_id"),
+                "structured": True,
+                "timestamp": ts,
+            }
+
+        if target_file == "Classes.json" and action == "create":
+            mgr = ClassManager(data_path, f"struct_{sid}")
+            r = await mgr.execute("create", target_info=target_info)
+            step_results[sid] = {**r, "step_id": sid}
+            return {
+                "step_id": sid,
+                "tool_name": "structured_classes_create",
+                "success": bool(r.get("success")),
+                "stdout": r.get("message", ""),
+                "stderr": r.get("error") or "",
+                "class_id": r.get("class_id"),
+                "structured": True,
+                "timestamp": ts,
+            }
+
         if target_file == "Actors.json" and action == "query":
             mgr = ActorManager(data_path, f"struct_{sid}")
             r = await mgr.execute("query", target_info=target_info)
@@ -200,6 +256,7 @@ async def _execute_one_structured_step(
 
         if target_file == "Actors.json" and action == "create":
             mgr = ActorManager(data_path, f"struct_{sid}")
+            # Planner가 class_id를 생략할 수 있어서 기본값(=1)으로 안전 처리한다.
             class_id = target_info.get("class_id", 1)
             try:
                 class_id = int(class_id)
@@ -217,6 +274,37 @@ async def _execute_one_structured_step(
                 "timestamp": ts,
             }
 
+        if target_file == "Actors.json" and action == "update":
+            mgr = ActorManager(data_path, f"struct_{sid}")
+            # MVP update는 `classId` 변경만 지원한다(=class_name 또는 class_id로 resolve).
+            r = await mgr.execute("update_class", target_info=target_info)
+            step_results[sid] = {**r, "step_id": sid}
+            return {
+                "step_id": sid,
+                "tool_name": "structured_actors_update",
+                "success": bool(r.get("success")),
+                "stdout": r.get("message", ""),
+                "stderr": r.get("error") or "",
+                "structured": True,
+                "timestamp": ts,
+            }
+
+        if target_file == "System.json" and action == "update":
+            mgr = SystemManager(data_path, f"struct_{sid}")
+            # MVP update는 `partyMembers`에 actor를 추가하는 케이스만 지원한다.
+            r = await mgr.execute("add_party_member", target_info=target_info)
+            step_results[sid] = {**r, "step_id": sid}
+            return {
+                "step_id": sid,
+                "tool_name": "structured_system_update",
+                "success": bool(r.get("success")),
+                "stdout": r.get("message", ""),
+                "stderr": r.get("error") or "",
+                "structured": True,
+                "timestamp": ts,
+            }
+
+        # 위 조건에 없는 target/action 조합은 현재 MVP에서 아직 구현되지 않았다는 뜻이다.
         err = f"지원하지 않는 구조화 스텝: {target_file!r} + {action!r}"
         step_results[sid] = {"success": False, "error": err, "step_id": sid}
         return {
@@ -246,7 +334,11 @@ async def _executor_structured(
     game_id: str,
     retry_count: int,
 ) -> dict[str, Any]:
-    """3단계 구조화 execution_plan 전용 실행 경로."""
+    """3단계 구조화 execution_plan 전용 실행 경로(4단계 엔진).
+
+    이 경로의 역할은 "planner가 준 step들을 올바른 순서로 실행"하고,
+    수정 전/후 스냅샷 및 백업을 묶어서 결과(`changes_log`)로 반환하는 것이다.
+    """
     ordered = _topological_sort_steps(execution_plan)
     target_files = sorted(_collect_structured_target_files(execution_plan))
     if not target_files:
@@ -259,6 +351,7 @@ async def _executor_structured(
         target_files,
     )
 
+    # snapshot/backup은 "실패했을 때 롤백"과 "실행 전/후 비교"를 위한 MVP 장치다.
     current_game_state = _create_snapshot(data_path, target_files)
     backup_paths = _create_backup(data_path, target_files)
 
@@ -266,6 +359,7 @@ async def _executor_structured(
     step_results: dict[int, dict] = {}
 
     for step in ordered:
+        # Planner output이 깨진 경우에도 전체 실행이 터지지 않게 방어한다.
         if not isinstance(step, dict):
             continue
         try:
@@ -273,8 +367,10 @@ async def _executor_structured(
         except (TypeError, ValueError):
             continue
 
+        # 의존성/조건 기반으로 "실행할지 말지" 먼저 판정
         should_run, skip_reason = _should_execute_structured_step(step, step_results)
         if not should_run:
+            # 스킵은 "에러"가 아니라 "조건 만족(예: 이미 존재)"인 케이스로 취급한다.
             step_results[sid] = {
                 "skipped": True,
                 "success": True,
@@ -368,6 +464,7 @@ async def executor(state: AgentState) -> dict:
     logger.info("[Executor MVP] 데이터 경로: %s", data_path)
 
     # ── 3단계 구조화 플랜 (action_type / step_id / target_file) ──
+    # 이 포맷이면 LLM 번역 단계(레거시) 없이 곧바로 4단계 구조화 엔진으로 분기한다.
     if _is_structured_execution_plan(execution_plan):
         return await _executor_structured(data_path, execution_plan, game_id, retry_count)
 

--- a/agent/tests/test_executor_mvp.py
+++ b/agent/tests/test_executor_mvp.py
@@ -11,7 +11,9 @@ from pathlib import Path
 from agent.graph.nodes.executor import executor
 from agent.graph.state import AgentState
 from app.backend.services.json_modify_tools.managers.actor_manager import ActorManager
+from app.backend.services.json_modify_tools.managers.class_manager import ClassManager
 from app.backend.services.json_modify_tools.managers.skill_manager import SkillManager
+from app.backend.services.json_modify_tools.managers.system_manager import SystemManager
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO)
@@ -142,6 +144,112 @@ async def test_structured_execution_plan_actors():
     logs2 = result2.get("changes_log", [])
     skipped = [x for x in logs2 if x.get("skipped")]
     assert any("존재" in (x.get("skip_reason") or "") for x in skipped)
+
+
+async def test_structured_execution_plan_full_update_flow():
+    """Classes/Actors/System 연계 query-create-update가 모두 동작하는지 검증."""
+    unique_suffix = uuid.uuid4().hex[:8]
+    class_name = f"ZZZ_CLASS_{unique_suffix}"
+    actor_name = f"ZZZ_ACTOR_{unique_suffix}"
+
+    # 4단계 엔진(Structured execution_plan)에서 아래 step들이 순서대로 실행돼야 한다.
+    # 1~2: Classes.json query -> create
+    # 3~4: Actors.json query -> create
+    # 5: Actors.json update(=classId 갱신)
+    # 6: System.json update(=partyMembers에 actorId 추가)
+    state: AgentState = {
+        "execution_plan": [
+            {
+                "step_id": 1,
+                "description": f"Classes.json에서 '{class_name}' 클래스 존재 여부 조회",
+                "action_type": "query",
+                "target_file": "Classes.json",
+                "target_info": {"class_name": class_name},
+                "depends_on": [],
+                "condition": "",
+            },
+            {
+                "step_id": 2,
+                "description": f"{class_name} 클래스가 없으면 생성",
+                "action_type": "create",
+                "target_file": "Classes.json",
+                "target_info": {"class_name": class_name},
+                "depends_on": [1],
+                "condition": "step 1에서 클래스가 존재하지 않을 경우",
+            },
+            {
+                "step_id": 3,
+                "description": f"Actors.json에서 '{actor_name}' 액터 존재 여부 조회",
+                "action_type": "query",
+                "target_file": "Actors.json",
+                "target_info": {"actor_name": actor_name},
+                "depends_on": [],
+                "condition": "",
+            },
+            {
+                "step_id": 4,
+                "description": f"{actor_name} 액터가 없으면 생성",
+                "action_type": "create",
+                "target_file": "Actors.json",
+                "target_info": {"actor_name": actor_name},
+                "depends_on": [3],
+                "condition": "step 3에서 액터가 존재하지 않을 경우",
+            },
+            {
+                "step_id": 5,
+                "description": "액터 classId를 클래스 인덱스로 업데이트",
+                "action_type": "update",
+                "target_file": "Actors.json",
+                "target_info": {"actor_name": actor_name, "class_name": class_name},
+                "depends_on": [1, 2, 3, 4],
+                "condition": "",
+            },
+            {
+                "step_id": 6,
+                "description": "System.partyMembers에 액터 추가",
+                "action_type": "update",
+                "target_file": "System.json",
+                "target_info": {"actor_name": actor_name},
+                "depends_on": [5],
+                "condition": "",
+            },
+        ],
+        "game_id": "game_001",
+        "retry_count": 0,
+    }
+
+    result = await executor(state)
+    logs = result.get("changes_log", [])
+    assert any(x.get("tool_name") == "structured_classes_query" for x in logs)
+    assert any(x.get("tool_name") == "structured_classes_create" for x in logs)
+    assert any(x.get("tool_name") == "structured_actors_query" for x in logs)
+    assert any(x.get("tool_name") == "structured_actors_create" for x in logs)
+    assert any(
+        x.get("tool_name") == "structured_actors_update" and x.get("success") is True for x in logs
+    )
+    assert any(
+        x.get("tool_name") == "structured_system_update" and x.get("success") is True for x in logs
+    )
+
+    data_path = Path(__file__).resolve().parents[2] / "storage" / "games" / "game_001" / "data"
+    class_mgr = ClassManager(data_path, "verify_class")
+    actor_mgr = ActorManager(data_path, "verify_actor")
+    system_mgr = SystemManager(data_path, "verify_system")
+
+    class_q = await class_mgr.execute("query", class_name=class_name)
+    actor_q = await actor_mgr.execute("query", actor_name=actor_name)
+    assert class_q.get("exists") is True
+    assert actor_q.get("exists") is True
+
+    actor_update = await actor_mgr.execute(
+        "update_class", target_info={"actor_name": actor_name, "class_name": class_name}
+    )
+    assert actor_update.get("success") is True
+
+    system_update = await system_mgr.execute(
+        "add_party_member", target_info={"actor_name": actor_name}
+    )
+    assert system_update.get("success") is True
 
 
 async def test_skill_manager_directly():

--- a/app/backend/services/json_modify_tools/managers/__init__.py
+++ b/app/backend/services/json_modify_tools/managers/__init__.py
@@ -2,3 +2,10 @@
 
 MVP 버전: 기존 edit_*.py 로직을 래핑하는 간단한 매니저들
 """
+
+from .actor_manager import ActorManager
+from .class_manager import ClassManager
+from .skill_manager import SkillManager
+from .system_manager import SystemManager
+
+__all__ = ["ActorManager", "ClassManager", "SkillManager", "SystemManager"]

--- a/app/backend/services/json_modify_tools/managers/actor_manager.py
+++ b/app/backend/services/json_modify_tools/managers/actor_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -33,11 +34,27 @@ class ActorManager(BaseManager):
             }
 
         try:
+            # Structured step의 action_type을 여기서는 "MVP 매니저 action"으로 매핑한다.
+            # - Planner step: Actors.json + (query/create/update)
+            # - 여기서 실제 호출: execute("query"/"create"/"update_class")
             if action == "query":
                 return self._handle_query(actor_name)
             if action == "create":
                 template_class_id = int(kwargs.get("class_id", 1))
                 return self._handle_create(actor_name, template_class_id)
+            if action == "update_class":
+                ti = (
+                    kwargs.get("target_info") if isinstance(kwargs.get("target_info"), dict) else {}
+                )
+                class_name = (ti.get("class_name") or kwargs.get("class_name") or "").strip()
+                class_id_raw = ti.get("class_id", kwargs.get("class_id"))
+                class_id: int | None = None
+                if class_id_raw is not None:
+                    try:
+                        class_id = int(class_id_raw)
+                    except (TypeError, ValueError):
+                        class_id = None
+                return self._handle_update_class(actor_name, class_name, class_id)
             return {
                 "success": False,
                 "error": f"MVP에서 지원하지 않는 액션: {action}",
@@ -48,6 +65,7 @@ class ActorManager(BaseManager):
             return {"success": False, "error": str(e), "category": "actors"}
 
     def _handle_query(self, actor_name: str) -> dict[str, Any]:
+        # RPG Maker MZ Actors.json은 배열이며, 0번 인덱스는 null로 고정되어 있다.
         data = self.load_json_data()
         if not isinstance(data, list) or not data or data[0] is not None:
             return {
@@ -71,6 +89,8 @@ class ActorManager(BaseManager):
         }
 
     def _handle_create(self, actor_name: str, template_class_id: int) -> dict[str, Any]:
+        # MVP에서는 "없을 때만 create"하도록 설계한다.
+        # 이미 존재하면 create를 진행하지 않고 success=False로 반환한다.
         data = self.load_json_data()
         if not isinstance(data, list) or not data or data[0] is not None:
             return {
@@ -102,6 +122,7 @@ class ActorManager(BaseManager):
         new_actor["nickname"] = ""
         new_actor["profile"] = ""
         note_tag = f"[AI_MODIFIED:{datetime.now().strftime('%Y-%m-%d')}]"
+        # 생성/수정된 항목임을 추적하기 위해 note에 태그를 남긴다.
         new_actor["note"] = (new_actor.get("note") or "").strip()
         if new_actor["note"]:
             new_actor["note"] = f"{new_actor['note']} {note_tag}"
@@ -125,7 +146,12 @@ class ActorManager(BaseManager):
         }
 
     def _pick_template_actor(self, data: list[Any], class_id: int) -> dict[str, Any] | None:
-        """동일 classId 우선, 없으면 id==1 액터, 그것도 없으면 첫 유효 dict."""
+        """동일 classId 우선으로 템플릿을 고른다.
+
+        - 같은 classId가 있으면 그 액터를 복사
+        - 없으면 id==1 액터(기본값으로 자주 존재)를 복사
+        - 그것도 없으면 첫 유효 dict를 복사(마지막 수단)
+        """
         for idx in range(1, len(data)):
             item = data[idx]
             if isinstance(item, dict) and int(item.get("classId") or 0) == class_id:
@@ -136,3 +162,90 @@ class ActorManager(BaseManager):
             if isinstance(data[idx], dict):
                 return data[idx]
         return None
+
+    def _handle_update_class(
+        self,
+        actor_name: str,
+        class_name: str,
+        class_id: int | None,
+    ) -> dict[str, Any]:
+        """액터의 `classId`를 갱신한다.
+
+        MVP 제약:
+        - class_id가 들어오면 바로 사용
+        - 없으면 `Classes.json`에서 class_name으로 classId를 resolve한 뒤 갱신
+        """
+        actors_data = self.load_json_data()
+        if not isinstance(actors_data, list) or not actors_data or actors_data[0] is not None:
+            return {
+                "success": False,
+                "error": "Actors.json 형식이 예상과 다릅니다 ([null, ...] 필요).",
+                "category": "actors",
+            }
+
+        actor_id = self.find_by_name(actors_data, actor_name)
+        if actor_id is None:
+            return {
+                "success": False,
+                "error": f"액터 '{actor_name}' 없음",
+                "category": "actors",
+            }
+
+        resolved_class_id = class_id
+        if resolved_class_id is None:
+            # Planner step이 `class_id` 없이 `class_name`만 줄 수도 있어서
+            # 여기서 Classes.json을 직접 읽어 resolve한다.
+            classes_path = self.data_path / "Classes.json"
+            if not classes_path.exists():
+                return {
+                    "success": False,
+                    "error": "Classes.json 파일 없음",
+                    "category": "actors",
+                }
+            with open(classes_path, encoding="utf-8") as f:
+                classes_data = json.load(f)
+            if (
+                not isinstance(classes_data, list)
+                or not classes_data
+                or classes_data[0] is not None
+            ):
+                return {
+                    "success": False,
+                    "error": "Classes.json 형식이 예상과 다릅니다 ([null, ...] 필요).",
+                    "category": "actors",
+                }
+            if not class_name:
+                return {
+                    "success": False,
+                    "error": "class_name 또는 class_id가 필요합니다.",
+                    "category": "actors",
+                }
+            class_idx = self.find_by_name(classes_data, class_name)
+            if class_idx is None:
+                return {
+                    "success": False,
+                    "error": f"클래스 '{class_name}' 없음",
+                    "category": "actors",
+                }
+            resolved_class_id = class_idx
+
+        target = actors_data[actor_id]
+        if not isinstance(target, dict):
+            return {
+                "success": False,
+                "error": f"액터 ID {actor_id} 형식이 올바르지 않습니다.",
+                "category": "actors",
+            }
+
+        target["classId"] = int(resolved_class_id)
+        self.save_json_data(actors_data)
+        return {
+            "success": True,
+            "action": "update_class",
+            "actor_id": actor_id,
+            "actor_name": actor_name,
+            "class_id": int(resolved_class_id),
+            "modified_files": ["Actors.json"],
+            "message": f"액터 '{actor_name}' classId를 {int(resolved_class_id)}로 수정",
+            "category": "actors",
+        }

--- a/app/backend/services/json_modify_tools/managers/class_manager.py
+++ b/app/backend/services/json_modify_tools/managers/class_manager.py
@@ -1,0 +1,121 @@
+"""Class Manager — Classes.json 전용 (구조화 execution_plan용 MVP)."""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .base_manager import BaseManager
+
+
+class ClassManager(BaseManager):
+    def get_file_path(self) -> Path:
+        return self.data_path / "Classes.json"
+
+    async def execute(self, action: str, **kwargs) -> dict[str, Any]:
+        # Structured step에서 넘어오는 값을 기반으로 query/create를 분기한다.
+        class_name = (kwargs.get("class_name") or "").strip()
+        if not class_name:
+            ti = kwargs.get("target_info")
+            if isinstance(ti, dict):
+                class_name = (ti.get("class_name") or ti.get("name") or "").strip()
+        if not class_name:
+            return {
+                "success": False,
+                "error": "class_name(또는 target_info.class_name)이 비어 있습니다.",
+                "category": "classes",
+            }
+
+        if action == "query":
+            return self._handle_query(class_name)
+        if action == "create":
+            return self._handle_create(class_name)
+        return {
+            "success": False,
+            "error": f"MVP에서 지원하지 않는 액션: {action}",
+            "category": "classes",
+        }
+
+    def _handle_query(self, class_name: str) -> dict[str, Any]:
+        # Classes.json 역시 RPG Maker 규칙상 [null, {...}, {...}] 구조를 기대한다.
+        data = self.load_json_data()
+        if not isinstance(data, list) or not data or data[0] is not None:
+            return {
+                "success": False,
+                "error": "Classes.json 형식이 예상과 다릅니다 ([null, ...] 필요).",
+                "category": "classes",
+            }
+        idx = self.find_by_name(data, class_name)
+        return {
+            "success": True,
+            "action": "query",
+            "exists": idx is not None,
+            "class_id": idx,
+            "class_name": class_name,
+            "message": (
+                f"클래스 '{class_name}' 존재 (id={idx})"
+                if idx is not None
+                else f"클래스 '{class_name}' 없음"
+            ),
+            "category": "classes",
+        }
+
+    def _handle_create(self, class_name: str) -> dict[str, Any]:
+        # MVP는 "없는 경우에만" 클래스를 생성한다. (있으면 error/exists 반환)
+        data = self.load_json_data()
+        if not isinstance(data, list) or not data or data[0] is not None:
+            return {
+                "success": False,
+                "error": "Classes.json 형식이 예상과 다릅니다 ([null, ...] 필요).",
+                "category": "classes",
+            }
+        if self.find_by_name(data, class_name):
+            return {
+                "success": False,
+                "exists": True,
+                "error": f"클래스 '{class_name}' 이미 존재합니다.",
+                "category": "classes",
+            }
+
+        # 템플릿 선택 규칙:
+        # - id==1(보통 기본값) 우선
+        # - 없으면 첫 유효 dict
+        template = None
+        if len(data) > 1 and isinstance(data[1], dict):
+            template = data[1]
+        if template is None:
+            for idx in range(1, len(data)):
+                if isinstance(data[idx], dict):
+                    template = data[idx]
+                    break
+        if template is None:
+            return {
+                "success": False,
+                "error": "템플릿 클래스를 찾을 수 없습니다.",
+                "category": "classes",
+            }
+
+        new_id = self.find_available_id(data)
+        new_class = copy.deepcopy(template)
+        new_class["id"] = new_id
+        new_class["name"] = class_name
+        note_tag = f"[AI_MODIFIED:{datetime.now().strftime('%Y-%m-%d')}]"
+        new_class["note"] = (new_class.get("note") or "").strip()
+        new_class["note"] = f"{new_class['note']} {note_tag}".strip()
+
+        if new_id == len(data):
+            data.append(new_class)
+        else:
+            data[new_id] = new_class
+        self.save_json_data(data)
+        return {
+            "success": True,
+            "action": "create",
+            "class_id": new_id,
+            "class_name": class_name,
+            "modified_files": ["Classes.json"],
+            "message": f"클래스 '{class_name}' 생성됨 (id={new_id})",
+            "category": "classes",
+        }

--- a/app/backend/services/json_modify_tools/managers/system_manager.py
+++ b/app/backend/services/json_modify_tools/managers/system_manager.py
@@ -1,0 +1,97 @@
+"""System Manager — System.json 전용 (구조화 execution_plan용 MVP)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .base_manager import BaseManager
+
+
+class SystemManager(BaseManager):
+    def get_file_path(self) -> Path:
+        return self.data_path / "System.json"
+
+    async def execute(self, action: str, **kwargs) -> dict[str, Any]:
+        if action == "add_party_member":
+            # Planner step: System.json + update(action_type="update")
+            # 여기서는 그 의미를 "partyMembers에 actor 추가"로 해석한다.
+            ti = kwargs.get("target_info") if isinstance(kwargs.get("target_info"), dict) else {}
+            actor_name = (ti.get("actor_name") or kwargs.get("actor_name") or "").strip()
+            return self._handle_add_party_member(actor_name)
+        return {
+            "success": False,
+            "error": f"MVP에서 지원하지 않는 액션: {action}",
+            "category": "system",
+        }
+
+    def _handle_add_party_member(self, actor_name: str) -> dict[str, Any]:
+        # partyMembers에는 "actorId" 목록이 들어가므로,
+        # actor_name을 Actors.json에서 actorId로 resolve한 뒤 System.json에 반영한다.
+        if not actor_name:
+            return {
+                "success": False,
+                "error": "actor_name이 비어 있습니다.",
+                "category": "system",
+            }
+
+        system = self.load_json_data()
+        if not isinstance(system, dict):
+            return {
+                "success": False,
+                "error": "System.json 형식이 예상과 다릅니다 (object 필요).",
+                "category": "system",
+            }
+
+        actors_path = self.data_path / "Actors.json"
+        if not actors_path.exists():
+            return {"success": False, "error": "Actors.json 파일 없음", "category": "system"}
+        with open(actors_path, encoding="utf-8") as f:
+            actors = json.load(f)
+        if not isinstance(actors, list) or not actors or actors[0] is not None:
+            return {
+                "success": False,
+                "error": "Actors.json 형식이 예상과 다릅니다 ([null, ...] 필요).",
+                "category": "system",
+            }
+
+        actor_id = self.find_by_name(actors, actor_name)
+        if actor_id is None:
+            return {
+                "success": False,
+                "error": f"액터 '{actor_name}' 없음",
+                "category": "system",
+            }
+
+        party = system.get("partyMembers")
+        if not isinstance(party, list):
+            return {
+                "success": False,
+                "error": "System.partyMembers 형식 오류",
+                "category": "system",
+            }
+
+        if actor_id in party:
+            # 동일 actorId가 이미 있으면 idempotent(멱등)하게 skip 처리한다.
+            return {
+                "success": True,
+                "action": "add_party_member",
+                "skipped": True,
+                "actor_id": actor_id,
+                "message": f"액터 '{actor_name}'(id={actor_id})는 이미 partyMembers에 존재",
+                "modified_files": [],
+                "category": "system",
+            }
+
+        party.append(actor_id)
+        self.save_json_data(system)
+        return {
+            "success": True,
+            "action": "add_party_member",
+            "actor_id": actor_id,
+            "actor_name": actor_name,
+            "message": f"액터 '{actor_name}'(id={actor_id})를 partyMembers에 추가",
+            "modified_files": ["System.json"],
+            "category": "system",
+        }


### PR DESCRIPTION
4단계 Executor가 3단계 Planner의 구조화 execution_plan(step_id/action_type/target_file/depends_on/condition)을 직접 해석해 실행하도록 확장했습니다.
depends_on 기반 위상 정렬로 실행 순서를 보장하고, condition이 있는 create는 선행 query 결과(exists)를 바탕으로 조건부 생성(이미 존재 시 스킵)하도록 처리했습니다.
구조화 실행 경로에서 수정 전/후 스냅샷(current_game_state/modified_game_state), changes_log, backup_paths를 일관되게 반환해 5단계 Validator 인수인계 호환을 유지했습니다.
Actors update(classId 갱신), Classes query/create, System update(partyMembers 추가)를 매니저 레이어로 분리해 3단계 예시 시나리오(step 1~6)가 end-to-end로 수행되도록 구현했습니다.

주요 기능

구조화 execution_plan 전용 실행 경로에서 의존성 정렬 + 조건부 스킵 + step별 결과 누적(step_results) 처리
Actors.json: query/create + update(class_name 또는 class_id 기반 classId 갱신) 지원
Classes.json: query/create 지원 (중복 생성 방지 및 템플릿 기반 생성)
System.json: update 지원 (actor_name → actorId resolve 후 partyMembers 반영, 중복 시 멱등 skip)
지원하지 않는 target_file/action_type 조합에 대한 명시적 실패 로그 반환으로 디버깅 가시성 확보
4단계 핵심 파일에 흐름/의도 중심 주석 보강으로 유지보수성 향상

관련 파일

agent/graph/nodes/executor.py
구조화 플랜 판별, target 파일 수집, depends_on 위상 정렬, 조건부 create 스킵, target_file/action_type별 매니저 디스패치, 구조화 실행 결과 반환
app/backend/services/json_modify_tools/managers/actor_manager.py
Actors.json 전용 query/create/update_class 구현, class_name 기반 classId resolve, AI_MODIFIED note 태그 유지
app/backend/services/json_modify_tools/managers/class_manager.py
Classes.json 전용 query/create MVP 구현(중복 체크, 템플릿 복사 생성)
app/backend/services/json_modify_tools/managers/system_manager.py
System.json 전용 add_party_member 구현(actor_name 기반 actorId 조회 후 partyMembers 반영)
app/backend/services/json_modify_tools/managers/__init__.py
Actor/Class/Skill/System 매니저 export 정리
agent/tests/test_executor_mvp.py
구조화 full flow(Classes→Actors→Actors update→System update) 통합 테스트 추가 및 검증 강화

추가로 수행한 검증/정리

uv run --extra dev pytest agent/tests/test_executor_mvp.py -q 실행 결과 4 passed
구조화 플랜의 query→create→update 연계 시나리오 및 재실행 시 스킵 동작 확인
수정 파일 대상 linter 점검 시 에러 없음 확인
4단계/매니저/테스트 코드에 의도 중심 주석 추가 완료

현재 범위 및 한계(MVP)

외부 MCP 연동 없이 로컬 매니저 기반으로 동작하는 MVP 형태
update는 범용 JSON 패치가 아니라 현재 정의된 도메인 동작(Actors classId, System partyMembers) 중심
지원 조합 외 target_file/action_type은 실패로 반환되며 후속 확장 필요
수도코드(레거시 task) 경로와 구조화 경로가 공존하며, 구조화 경로 기준 자체 테스트는 통과한 상태