### PR TITLE
feat : AWS 연동 백엔드 설정(Vercel·RDS·S3·CORS) + 구조화 execution_plan Executo…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,50 +1,31 @@
-# Re:Verse 환경변수 예시
-# 이 파일을 복사해서 .env 로 저장한 뒤 값을 채우세요
-# cp .env.example .env
-
-# ── 앱 설정 ────────────────────────────────────────────────
+# ── 공통 ─────────────────────────────────────────────────────
 ENVIRONMENT=development
-DEBUG=True
+DEBUG=true
 
-# ── CORS ───────────────────────────────────────────────────
-CORS_ORIGINS=["http://localhost:3000","https://*.vercel.app"]
+# CORS (쉼표 구분, FastAPI allow_origins)
+CORS_ORIGINS=http://localhost:5173,http://localhost:3000,https://re-verse.ai.kr
 
-# ── LLM 설정 ───────────────────────────────────────────────
-# OpenAI 호환 API라면 어디든 사용 가능
-#
-# [Solar / Upstage]
-#   LLM_API_KEY=up_xxxx
-#   LLM_MODEL=solar-pro
-#   LLM_BASE_URL=https://api.upstage.ai/v1
-#
-# [OpenAI]
-#   LLM_API_KEY=sk-xxxx
-#   LLM_MODEL=gpt-4o
-#   LLM_BASE_URL=                          # 비우면 공식 OpenAI 엔드포인트
-#
-# [vLLM / Together AI 등 호환 API]
-#   LLM_API_KEY=your_key
-#   LLM_MODEL=Llama-3.1-8B
-#   LLM_BASE_URL=http://localhost:8001/v1
-
-LLM_API_KEY=
-LLM_MODEL=solar-pro
-LLM_BASE_URL=https://api.upstage.ai/v1
-
-# ── LangSmith (선택) ────────────────────────────────────────
-# https://smith.langchain.com 에서 API 키 발급
-# LANGSMITH_TRACING=True 로 설정하면 모든 LLM 호출이 트레이싱됨
-LANGSMITH_API_KEY=
-LANGSMITH_PROJECT=Re-Verse
-LANGSMITH_TRACING=False
-
-# ── Storage ─────────────────────────────────────────────────
+# 게임 파일 (에이전트/정적 서빙)
+# 로컬: ./storage/games
+# Docker(EC2): /app/storage/games 등 절대 경로 권장
 STORAGE_PATH=./storage/games
 
-# ── Agent ───────────────────────────────────────────────────
-AGENT_TIMEOUT=30
-MAX_RETRIES=3
+# local | s3 — 프로덕션 EC2에서는 s3 + IAM 역할
+STORAGE_BACKEND=local
 
-# ── Frontend (Vite) ─────────────────────────────────────────
-VITE_API_URL=/api
-VITE_USE_MOCK=false
+# ── AWS (S3, EC2 IAM 역할 시 키 불필요) ───────────────────────
+AWS_REGION=ap-northeast-2
+S3_BUCKET_NAME=upstage-sesac-31-reverse-project-s3
+# 버킷 내 prefix (키: {S3_PREFIX}/{game_id}/data/Actors.json)
+S3_PREFIX=games
+
+# ── RDS PostgreSQL ────────────────────────────────────────────
+# 비우면 DB 엔진 미생성 (/health/db 는 skipped)
+# RDS는 sslmode=require 권장
+# DATABASE_URL=postgresql+psycopg://USER:PASS@HOSTNAME:5432/DBNAME?sslmode=require
+
+DATABASE_URL=
+
+# ── LLM / LangSmith (기존) ───────────────────────────────────
+# LLM_API_KEY=
+# LANGSMITH_API_KEY=

--- a/agent/graph/nodes/executor.py
+++ b/agent/graph/nodes/executor.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, Field
 
 from agent.core.llm_client import invoke_llm
 from agent.graph.state import AgentState
+from app.backend.core.game_paths import get_game_data_path
 from app.backend.services.json_modify_tools.dispatcher import (
     run_enemies,
     run_items,
@@ -613,9 +614,8 @@ async def executor(state: AgentState) -> dict:
 
 
 def _get_data_path(game_id: str) -> Path:
-    """게임 데이터 경로 계산 (executor 위치: agent/graph/nodes/ → 루트는 parents[3])."""
-    root = Path(__file__).resolve().parents[3]  # Re-Verse/
-    return root / "storage" / "games" / game_id / "data"
+    """게임 `data/` 경로. `STORAGE_PATH` 설정과 동일(로컬 개발 vs EC2+S3 동기화 경로)."""
+    return get_game_data_path(game_id)
 
 
 def _create_snapshot(data_path: Path, target_files: list[str]) -> dict[str, Any]:

--- a/app/backend/core/config.py
+++ b/app/backend/core/config.py
@@ -1,23 +1,41 @@
 """
 Configuration Settings
 환경 변수를 관리하는 설정 파일
+
+배포 시(EC2 Docker) GitHub Actions의 ENV_FILE 시크릿으로 .env가 생성되며,
+로컬은 .env 또는 기본값을 사용합니다.
 """
 
-from pydantic_settings import BaseSettings
+import json
+from typing import Literal
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """애플리케이션 설정"""
 
-    # App Settings
-    ENVIRONMENT: str = "development"  # 로컬: development, 배포: production
-    DEBUG: bool = True  # 로컬: True, 배포: False
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=True,
+        extra="ignore",
+    )
 
-    # CORS
-    CORS_ORIGINS: list[str] = [
-        "http://localhost:3000",  # 로컬 프론트엔드
-        "https://*.vercel.app",  # Vercel 배포된 프론트엔드
-    ]
+    # App Settings
+    ENVIRONMENT: str = "development"  # development | production
+    DEBUG: bool = True
+
+    # ── CORS (프론트: Vercel https://re-verse.ai.kr 등) ─────────────────
+    # 쉼표로 구분. FastAPI는 와일드카드 origin을 신뢰하지 않으므로 도메인을 명시합니다.
+    CORS_ORIGINS: str = Field(
+        default=(
+            "http://localhost:5173,http://localhost:3000,"
+            "https://re-verse.ai.kr,https://www.re-verse.ai.kr"
+        ),
+        description="허용 Origin 목록 (쉼표 구분)",
+    )
 
     # Upstage API
     UPSTAGE_API_KEY: str = ""
@@ -29,18 +47,50 @@ class Settings(BaseSettings):
     LANGSMITH_PROJECT: str = "Re-Verse_project"
     LANGSMITH_TRACING: bool = True
 
-    # Storage
+    # ── 게임 파일 저장 ────────────────────────────────────────────────
+    # 로컬 개발: ./storage/games (그대로 파일 수정)
+    # 프로덕션: EC2 컨테이너 내 경로 + S3 동기화(STORAGE_BACKEND=s3)
     STORAGE_PATH: str = "./storage/games"
 
+    # local: 디스크만 사용 | s3: 요청 시 S3에서 받아 수정 후 다시 업로드
+    STORAGE_BACKEND: Literal["local", "s3"] = "local"
+
+    # AWS S3 (EC2 IAM 역할 사용 시 ACCESS_KEY 불필요)
+    AWS_REGION: str = "ap-northeast-2"
+    S3_BUCKET_NAME: str = "upstage-sesac-31-reverse-project-s3"
+    # 버킷 내 게임 루트 prefix (키 예: games/game_001/data/Actors.json)
+    S3_PREFIX: str = "games"
+
+    # RDS PostgreSQL (비어 있으면 DB 엔진 미생성, 헬스는 skipped)
+    # 예: postgresql+psycopg://user:pass@host:5432/dbname?sslmode=require
+    DATABASE_URL: str = ""
+
     # Agent Settings
-    AGENT_TIMEOUT: int = 30  # seconds
+    AGENT_TIMEOUT: int = 30
     MAX_RETRIES: int = 3
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        case_sensitive = True
-        extra = "ignore"
+    @field_validator("S3_PREFIX", mode="before")
+    @classmethod
+    def normalize_s3_prefix(cls, v: str) -> str:
+        """앞뒤 슬래시 제거 — 키 조합 시 일관되게 붙임."""
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return "games"
+        return str(v).strip().strip("/")
+
+    def cors_origins_list(self) -> list[str]:
+        """CORSMiddleware용 리스트.
+
+        `.env`에서 쉼표 구분 또는 JSON 배열(`["http://a","https://b"]`) 둘 다 허용.
+        """
+        raw = self.CORS_ORIGINS.strip()
+        if raw.startswith("["):
+            try:
+                data = json.loads(raw)
+                if isinstance(data, list):
+                    return [str(x).strip() for x in data if str(x).strip()]
+            except json.JSONDecodeError:
+                pass
+        return [x.strip() for x in raw.split(",") if x.strip()]
 
 
 # 전역 설정 인스턴스

--- a/app/backend/core/game_paths.py
+++ b/app/backend/core/game_paths.py
@@ -1,0 +1,26 @@
+"""게임 데이터 디스크 경로 (로컬 storage 또는 EC2 컨테이너 내 동기화 디렉터리).
+
+프로덕션에서 STORAGE_BACKEND=s3일 때는 요청 전후로 S3와 이 경로를 동기화합니다.
+에이전트/JSON 매니저는 항상 이 로컬 경로만 읽고 씁니다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.backend.core.config import settings
+
+
+def get_storage_root() -> Path:
+    """STORAGE_PATH (예: ./storage/games 또는 /app/storage/games) 절대 경로."""
+    return Path(settings.STORAGE_PATH).resolve()
+
+
+def get_game_root(game_id: str) -> Path:
+    """특정 게임 루트: {STORAGE_PATH}/{game_id}/"""
+    return get_storage_root() / game_id
+
+
+def get_game_data_path(game_id: str) -> Path:
+    """RPG Maker `data/` 폴더 (Actors.json 등). {STORAGE_PATH}/{game_id}/data/"""
+    return get_game_root(game_id) / "data"

--- a/app/backend/db/base.py
+++ b/app/backend/db/base.py
@@ -1,0 +1,7 @@
+"""SQLAlchemy 선언적 베이스 (향후 Alembic/모델 확장 시 사용)."""
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/app/backend/db/session.py
+++ b/app/backend/db/session.py
@@ -1,0 +1,64 @@
+"""RDS(PostgreSQL) 연결 세션.
+
+DATABASE_URL이 비어 있으면 엔진을 만들지 않으며, 앱은 DB 없이도 기동할 수 있습니다.
+프로덕션 .env에는 GitHub Secret ENV_FILE로 주입한 연결 문자열을 넣습니다.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.backend.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_engine: Engine | None = None
+_SessionLocal: sessionmaker[Session] | None = None
+
+
+def get_engine() -> Engine | None:
+    """DATABASE_URL이 있을 때만 엔진 생성(지연 초기화)."""
+    global _engine, _SessionLocal
+    if _engine is not None:
+        return _engine
+    if not settings.DATABASE_URL or not settings.DATABASE_URL.strip():
+        return None
+    _engine = create_engine(
+        settings.DATABASE_URL,
+        pool_pre_ping=True,
+        pool_size=5,
+        max_overflow=10,
+    )
+    _SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+    logger.info("SQLAlchemy engine 초기화 완료")
+    return _engine
+
+
+def get_db() -> Generator[Session, None, None]:
+    """FastAPI Depends용 DB 세션 제너레이터."""
+    get_engine()
+    if _SessionLocal is None:
+        raise RuntimeError("DATABASE_URL이 설정되지 않았습니다.")
+    db = _SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def check_database_connection() -> tuple[bool, str]:
+    """헬스체크: SELECT 1."""
+    eng = get_engine()
+    if eng is None:
+        return True, "skipped (DATABASE_URL empty)"
+    try:
+        with eng.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        return True, "ok"
+    except Exception as e:
+        return False, str(e)

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -1,11 +1,12 @@
 """
 Re:Verse Backend - FastAPI 진입점
 
-이 파일은 Docker 컨테이너에서 uvicorn app.backend.main:app으로 실행되는 진입점입니다.
-실제 구현 시 FastAPI 앱을 여기에 정의해야 합니다.
+Docker(EC2)에서 `uvicorn app.backend.main:app` 으로 실행됩니다.
+프론트(Vercel https://re-verse.ai.kr)는 `vercel.json` rewrites로 `/api` → `https://api.re-verse.ai.kr` 로 프록시합니다.
 """
 
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -15,15 +16,24 @@ from loguru import logger
 from agent.monitoring.langsmith_setup import setup_langsmith
 from app.backend.api.v1 import api_router
 from app.backend.core.config import settings
+from app.backend.db.session import check_database_connection, get_engine
+from app.backend.services.s3_game_storage import check_s3_bucket_access
 
 
-# lifespan 이벤트 : 앱 시작/종료 시 실행
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
     logger.info("🚀 Re:Verse Backend Starting...")
     logger.info(f"Environment: {settings.ENVIRONMENT}")
     logger.info(f"Debug Mode: {settings.DEBUG}")
+    logger.info(f"Storage: backend={settings.STORAGE_BACKEND}, path={settings.STORAGE_PATH}")
+
+    # 게임 정적 서빙/에이전트가 쓸 디렉터리 보장
+    Path(settings.STORAGE_PATH).mkdir(parents=True, exist_ok=True)
+
+    # DB 엔진 선로딩(선택)
+    get_engine()
+
     setup_langsmith()
 
     yield
@@ -32,7 +42,6 @@ async def lifespan(app: FastAPI):
     logger.info("👋 Re:Verse Backend Shutting down...")
 
 
-# FastAPI 앱 인스턴스 생성
 app = FastAPI(
     title="Re:Verse API",
     description="AI-powered RPG game creation tool using natural language",
@@ -40,46 +49,50 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS 설정 (Vercel 프론트엔드와의 통신을 위해)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.CORS_ORIGINS,
+    allow_origins=settings.cors_origins_list(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
 
-# 헬스체크 엔드포인트 (Docker 헬스체크용)
 @app.get("/health")
 async def health_check():
-    """
-    헬스체크 엔드포인트
-    Docker 컨테이너의 HEALTHCHECK에서 사용됩니다.
-    """
+    """Docker HEALTHCHECK 및 로드밸런서용 기본 헬스."""
     return {"status": "healthy", "message": "Re:Verse Backend is running"}
 
 
-# 기본 루트 엔드포인트
+@app.get("/health/db")
+async def health_database():
+    """RDS 연결 확인. DATABASE_URL 미설정 시 skipped."""
+    ok, detail = check_database_connection()
+    return {"ok": ok, "detail": detail}
+
+
+@app.get("/health/s3")
+async def health_s3():
+    """S3 버킷 접근(IAM). STORAGE_BACKEND=local 이면 skipped."""
+    ok, detail = check_s3_bucket_access()
+    return {"ok": ok, "detail": detail}
+
+
 @app.get("/")
 async def root():
-    """
-    API 루트 엔드포인트
-    """
     return {"message": "Welcome to Re:Verse API", "docs": "/docs", "health": "/health"}
 
 
-# API 라우터들은 여기서 include 하세요
-# 예: app.include_router(llm_router, prefix="/api/v1")
 app.include_router(api_router, prefix="/api/v1")
 
-# storage/games 정적 파일 서빙 (게임 뷰어용)
-app.mount("/game", StaticFiles(directory=settings.STORAGE_PATH, html=True), name="game")
+# 게임 뷰어: 로컬/EC2 모두 STORAGE_PATH 아래 파일을 그대로 서빙 (프로덕션은 S3 동기화 후 동일 경로)
+app.mount(
+    "/game",
+    StaticFiles(directory=settings.STORAGE_PATH, html=True),
+    name="game",
+)
 
 if __name__ == "__main__":
     import uvicorn
 
-    # Production Environment
-    # uvicorn.run(app, host="0.0.0.0", port=8000)
-    # Development Environment
     uvicorn.run("app.backend.main:app", host="0.0.0.0", port=8000, reload=settings.DEBUG)

--- a/app/backend/services/llm_service.py
+++ b/app/backend/services/llm_service.py
@@ -14,6 +14,7 @@ from app.backend.services.json_modify_tools.dispatcher import (
     run_map_villager,
     run_skills,
 )
+from app.backend.services.s3_game_storage import sync_game_from_s3, sync_game_to_s3
 
 
 class LLMService:
@@ -33,10 +34,15 @@ class LLMService:
         Returns:
             AgentResponse: Agent 처리 결과
         """
-        try:
-            # Agent 호출 (현재는 mock, 실제로는 agent 모듈 호출)
-            agent_result = await self._call_agent(user_request)
+        # 프로덕션(S3): 요청 전 해당 game_id 폴더를 S3에서 내려받아 로컬에서 수정한 뒤 성공 시 다시 업로드
+        gid = user_request.game_id or "game_001"
+        if settings.STORAGE_BACKEND == "s3":
+            await asyncio.to_thread(sync_game_from_s3, gid)
 
+        try:
+            agent_result = await self._call_agent(user_request)
+            if settings.STORAGE_BACKEND == "s3" and agent_result.success:
+                await asyncio.to_thread(sync_game_to_s3, gid)
             return agent_result
 
         except TimeoutError:

--- a/app/backend/services/s3_game_storage.py
+++ b/app/backend/services/s3_game_storage.py
@@ -1,0 +1,100 @@
+"""S3 ↔ 로컬 디스크 게임 폴더 동기화 (프로덕션용).
+
+EC2 IAM 역할로 boto3가 자격 증명을 받습니다(ACCESS_KEY 불필요).
+버킷 키 규칙: {S3_PREFIX}{game_id}/... 예: games/game_001/data/Actors.json
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+from app.backend.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _s3_client():
+    return boto3.client("s3", region_name=settings.AWS_REGION)
+
+
+def _game_s3_prefix(game_id: str) -> str:
+    """games/game_001/ 형태 (끝에 /)."""
+    base = settings.S3_PREFIX.strip("/")
+    return f"{base}/{game_id}/"
+
+
+def sync_game_from_s3(game_id: str) -> None:
+    """S3의 games/{game_id}/ 아래 객체를 STORAGE_PATH/{game_id}/ 로 내려받는다."""
+    if settings.STORAGE_BACKEND != "s3":
+        return
+
+    client = _s3_client()
+    bucket = settings.S3_BUCKET_NAME
+    prefix = _game_s3_prefix(game_id)
+    local_root = Path(settings.STORAGE_PATH).resolve() / game_id
+    local_root.mkdir(parents=True, exist_ok=True)
+
+    paginator = client.get_paginator("list_objects_v2")
+    downloaded = 0
+    try:
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith("/"):
+                    continue
+                rel = key[len(prefix) :].lstrip("/")
+                if not rel:
+                    continue
+                dest = local_root / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                client.download_file(bucket, key, str(dest))
+                downloaded += 1
+    except ClientError as e:
+        logger.error("S3 download 실패 game_id=%s: %s", game_id, e)
+        raise
+
+    logger.info("S3 → 로컬 동기화 완료 game_id=%s files=%d", game_id, downloaded)
+
+
+def sync_game_to_s3(game_id: str) -> None:
+    """STORAGE_PATH/{game_id}/ 전체를 S3 prefix games/{game_id}/ 로 업로드한다."""
+    if settings.STORAGE_BACKEND != "s3":
+        return
+
+    local_root = Path(settings.STORAGE_PATH).resolve() / game_id
+    if not local_root.is_dir():
+        logger.warning("업로드할 로컬 게임 폴더 없음: %s", local_root)
+        return
+
+    client = _s3_client()
+    bucket = settings.S3_BUCKET_NAME
+    prefix = _game_s3_prefix(game_id)
+    uploaded = 0
+    try:
+        for path in local_root.rglob("*"):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(local_root)
+            key = f"{prefix}{rel.as_posix()}"
+            client.upload_file(str(path), bucket, key)
+            uploaded += 1
+    except ClientError as e:
+        logger.error("S3 upload 실패 game_id=%s: %s", game_id, e)
+        raise
+
+    logger.info("로컬 → S3 업로드 완료 game_id=%s files=%d", game_id, uploaded)
+
+
+def check_s3_bucket_access() -> tuple[bool, str]:
+    """헬스체크용: ListBucket 또는 HeadBucket 수준으로 접근 가능 여부."""
+    if settings.STORAGE_BACKEND != "s3":
+        return True, "skipped (STORAGE_BACKEND=local)"
+    try:
+        _s3_client().head_bucket(Bucket=settings.S3_BUCKET_NAME)
+        return True, "ok"
+    except ClientError as e:
+        return False, str(e)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - ENVIRONMENT=production
       - DEBUG=false
+      # STORAGE_BACKEND, DATABASE_URL, S3_* 는 EC2의 .env(또는 GitHub ENV_FILE)에서 주입 권장
     volumes: []  # 프로덕션에서는 볼륨 마운트 제거 (override)
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - ./app/backend:/app/app/backend
       - ./agent:/app/agent
       - ./shared:/app/shared
+      # 로컬 storage/games ↔ 컨테이너 (STORAGE_PATH 기본 ./storage/games)
+      - ./storage:/app/storage
     restart: unless-stopped
 
   # 프론트엔드 개발 서버 (선택사항 - 로컬에서 함께 띄우고 싶을 때만)

--- a/docs/AWS_ENV_SETUP.md
+++ b/docs/AWS_ENV_SETUP.md
@@ -1,0 +1,47 @@
+# AWS + Vercel 연동 요약 (이번에 코드에 반영된 내용)
+
+## 프론트 (Vercel)
+
+- 프로덕션 URL: `https://re-verse.ai.kr`
+- API는 `vercel.json`의 `rewrites`로 `/api/*` → `https://api.re-verse.ai.kr/api/*` 로 전달합니다.
+- `/game/*` 도 동일하게 API 도메인으로 프록시합니다.
+- 빌드 시 `VITE_API_URL=/api` 로 상대 경로 호출을 유지합니다.
+
+## 백엔드 (EC2 Docker)
+
+- 공개 API 베이스: `https://api.re-verse.ai.kr` (Nginx 등으로 443 → 백엔드 8000 프록시 가정)
+- CORS는 `CORS_ORIGINS`로 제어합니다. **쉼표 구분** 또는 **JSON 배열 문자열** 둘 다 지원합니다.
+- 프로덕션 `ENV_FILE`에는 반드시 `https://re-verse.ai.kr` 을 포함하세요. `https://*.vercel.app` 같은 와일드카드는 Starlette CORS에서 기대대로 동작하지 않을 수 있습니다.
+
+## 저장소 이중 모드
+
+| 모드 | 설명 |
+|------|------|
+| `STORAGE_BACKEND=local` | `STORAGE_PATH` 아래만 사용 (로컬 개발·테스트) |
+| `STORAGE_BACKEND=s3` | 요청 처리 전 S3에서 `games/{game_id}/` 를 내려받고, LLM 처리 성공 후 다시 업로드 |
+
+- S3 버킷: `upstage-sesac-31-reverse-project-s3`
+- Prefix: `games` → 객체 키 예: `games/game_001/data/Actors.json`
+- EC2 IAM 역할에 `s3:GetObject`, `s3:PutObject`, `s3:ListBucket` 등 부여
+
+## RDS
+
+- `DATABASE_URL` 이 비어 있으면 SQLAlchemy 엔진을 만들지 않으며, `/health/db` 는 `skipped` 로 응답합니다.
+- 설정 시 PostgreSQL + `psycopg` 드라이버 URL 예:
+  `postgresql+psycopg://user:pass@host:5432/dbname?sslmode=require`
+
+## GitHub Actions
+
+- 기존처럼 `ENV_FILE` 시크릿에 위 변수들이 포함된 `.env` 전체를 넣으면 EC2 배포 시 동일하게 적용됩니다.
+
+## 변경·추가된 주요 파일
+
+- `app/backend/core/config.py` — CORS, S3, RDS, STORAGE_BACKEND
+- `app/backend/core/game_paths.py` — 게임 `data/` 경로 단일화
+- `app/backend/services/s3_game_storage.py` — S3 동기화
+- `app/backend/db/session.py`, `db/base.py` — RDS 연결
+- `app/backend/main.py` — CORS, `/health/db`, `/health/s3`, storage 디렉터리 생성
+- `app/backend/services/llm_service.py` — S3 모드 시 동기화 훅
+- `agent/graph/nodes/executor.py` — `_get_data_path` 가 `STORAGE_PATH` 기준으로 통일
+- `vercel.json` — API 도메인 `https://api.re-verse.ai.kr`
+- `.env.example` — 변수 템플릿

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "langchain-community>=0.3.0",
     "langchain-openai>=0.2.0",
     "langsmith>=0.1.0",
+    "boto3>=1.42.77",
+    "sqlalchemy>=2.0.48",
+    "psycopg[binary]>=3.3.3",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -154,6 +154,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.77"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/f6/b280afd91b2284744c0bb26afa1272bd60270726b4d3999fc27b68200854/boto3-1.42.77.tar.gz", hash = "sha256:c6d9b05e5b86767d4c6ef762f155c891366e5951162f71d030e109fe531f4fd9", size = 112773, upload-time = "2026-03-26T19:25:35.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/e6/e27fb0956bd52e6ac222d47eaa04d267887ca1d52a6b3c25d2006c8dc9e6/boto3-1.42.77-py3-none-any.whl", hash = "sha256:95eb3ef693068586f70ca3f29c43701c34a9a73d0df413ea7eaff138efa4a6b9", size = 140555, upload-time = "2026-03-26T19:25:32.069Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.77"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/97/1800633988e890b4eea0706b2671342eddfeb33c1eb1d2fe28a8117f7907/botocore-1.42.77.tar.gz", hash = "sha256:cbb0ac410fab4aa0839a521329f970b271ec298d67465ed7fa7d095c0dad9f48", size = 15023911, upload-time = "2026-03-26T19:25:21.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/7c/6280e6b61f8c232eebd72cae950ed52ce2f38fecf2d178713de3cb1f6298/botocore-1.42.77-py3-none-any.whl", hash = "sha256:807bc2c3825bec6f025506ceeba5f7f111a00de8d58f35c679ee16c8ff6e7b10", size = 14699672, upload-time = "2026-03-26T19:25:15.996Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -777,6 +805,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1638,6 +1675,64 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/15/021be5c0cbc5b7c1ab46e91cc3434eb42569f79a0592e67b8d25e66d844d/psycopg_binary-3.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6698dbab5bcef8fdb570fc9d35fd9ac52041771bfcfe6fd0fc5f5c4e36f1e99d", size = 4591170, upload-time = "2026-02-18T16:48:55.594Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/54/a60211c346c9a2f8c6b272b5f2bbe21f6e11800ce7f61e99ba75cf8b63e1/psycopg_binary-3.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:329ff393441e75f10b673ae99ab45276887993d49e65f141da20d915c05aafd8", size = 4670009, upload-time = "2026-02-18T16:49:03.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/53/ac7c18671347c553362aadbf65f92786eef9540676ca24114cc02f5be405/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:eb072949b8ebf4082ae24289a2b0fd724da9adc8f22743409d6fd718ddb379df", size = 5469735, upload-time = "2026-02-18T16:49:10.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c3/4f4e040902b82a344eff1c736cde2f2720f127fe939c7e7565706f96dd44/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:263a24f39f26e19ed7fc982d7859a36f17841b05bebad3eb47bb9cd2dd785351", size = 5152919, upload-time = "2026-02-18T16:49:16.335Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/d929679c6a5c212bcf738806c7c89f5b3d0919f2e1685a0e08d6ff877945/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5152d50798c2fa5bd9b68ec68eb68a1b71b95126c1d70adaa1a08cd5eefdc23d", size = 6738785, upload-time = "2026-02-18T16:49:22.687Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b0/09703aeb69a9443d232d7b5318d58742e8ca51ff79f90ffe6b88f1db45e7/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d6a1e56dd267848edb824dbeb08cf5bac649e02ee0b03ba883ba3f4f0bd54f2", size = 4979008, upload-time = "2026-02-18T16:49:27.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a6/e662558b793c6e13a7473b970fee327d635270e41eded3090ef14045a6a5/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73eaaf4bb04709f545606c1db2f65f4000e8a04cdbf3e00d165a23004692093e", size = 4508255, upload-time = "2026-02-18T16:49:31.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/0f8b2e1d5e0093921b6f324a948a5c740c1447fbb45e97acaf50241d0f39/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:162e5675efb4704192411eaf8e00d07f7960b679cd3306e7efb120bb8d9456cc", size = 4189166, upload-time = "2026-02-18T16:49:35.801Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ec/ce2e91c33bc8d10b00c87e2f6b0fb570641a6a60042d6a9ae35658a3a797/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:fab6b5e37715885c69f5d091f6ff229be71e235f272ebaa35158d5a46fd548a0", size = 3924544, upload-time = "2026-02-18T16:49:41.129Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2f/7718141485f73a924205af60041c392938852aa447a94c8cbd222ff389a1/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a4aab31bd6d1057f287c96c0effca3a25584eb9cc702f282ecb96ded7814e830", size = 4235297, upload-time = "2026-02-18T16:49:46.726Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f9/1add717e2643a003bbde31b1b220172e64fbc0cb09f06429820c9173f7fc/psycopg_binary-3.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:59aa31fe11a0e1d1bcc2ce37ed35fe2ac84cd65bb9036d049b1a1c39064d0f14", size = 3547659, upload-time = "2026-02-18T16:49:52.999Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1964,6 +2059,7 @@ name = "re-verse"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "langchain" },
@@ -1972,9 +2068,11 @@ dependencies = [
     { name = "langgraph" },
     { name = "langsmith" },
     { name = "loguru" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "sqlalchemy" },
     { name = "supabase" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
@@ -1991,6 +2089,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.42.77" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "langchain", specifier = ">=0.3.0" },
@@ -2001,12 +2100,14 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
+    { name = "sqlalchemy", specifier = ">=2.0.48" },
     { name = "supabase", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
     { name = "websockets", specifier = ">=13.0" },
@@ -2178,6 +2279,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/3a/950367aee7c69027f4f422059227b290ed780366b6aecee5de5039d50fa8/ruff-0.15.5-py3-none-win32.whl", hash = "sha256:732e5ee1f98ba5b3679029989a06ca39a950cced52143a0ea82a2102cb592b74", size = 10551676, upload-time = "2026-03-05T20:06:13.705Z" },
     { url = "https://files.pythonhosted.org/packages/b8/00/bf077a505b4e649bdd3c47ff8ec967735ce2544c8e4a43aba42ee9bf935d/ruff-0.15.5-py3-none-win_amd64.whl", hash = "sha256:821d41c5fa9e19117616c35eaa3f4b75046ec76c65e7ae20a333e9a8696bc7fe", size = 11678972, upload-time = "2026-03-05T20:06:45.379Z" },
     { url = "https://files.pythonhosted.org/packages/fe/4e/cd76eca6db6115604b7626668e891c9dd03330384082e33662fb0f113614/ruff-0.15.5-py3-none-win_arm64.whl", hash = "sha256:b498d1c60d2fe5c10c45ec3f698901065772730b411f164ae270bb6bfcc4740b", size = 10965572, upload-time = "2026-03-05T20:06:16.984Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]
@@ -2440,6 +2553,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]

--- a/vercel.json
+++ b/vercel.json
@@ -5,11 +5,11 @@
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "http://34.226.65.141:8000/api/:path*"
+      "destination": "https://api.re-verse.ai.kr/api/:path*"
     },
     {
       "source": "/game/:path*",
-      "destination": "http://34.226.65.141:8000/game/:path*"
+      "destination": "https://api.re-verse.ai.kr/game/:path*"
     }
   ],
   "env": {


### PR DESCRIPTION
## 요약

AWS·배포 환경에 맞춰 백엔드 설정과 저장소(S3/RDS) 연동을 추가
---

## AWS · 배포 · 백엔드

### Vercel / 프론트 연동
- `vercel.json`: `/api`, `/game` → `https://api.re-verse.ai.kr` 로 rewrite (프로덕션 API 도메인과 정합)

### 설정 (`app/backend/core/config.py`)
- **CORS**: `CORS_ORIGINS` — 쉼표 구분 및 JSON 배열 문자열 형식 모두 지원
- **게임 저장**: `STORAGE_PATH`, `STORAGE_BACKEND` (`local` | `s3`)
- **S3**: `AWS_REGION`, `S3_BUCKET_NAME`, `S3_PREFIX` (기본 키: `games/{game_id}/...`)
- **RDS**: `DATABASE_URL` (비어 있으면 DB 엔진 미생성, 헬스는 skipped)

### 경로 단일화
- `app/backend/core/game_paths.py`: `{STORAGE_PATH}/{game_id}/data` 일원화
- `agent/graph/nodes/executor.py`: `_get_data_path`가 위 경로를 사용 (프로젝트 루트 하드코딩 제거)

### S3 동기화 (`app/backend/services/s3_game_storage.py`)
- EC2 **IAM 역할** 기준 boto3 (별도 ACCESS_KEY 미필요)
- `STORAGE_BACKEND=s3`일 때 `llm_service`에서 요청 전후 **S3 ↔ 로컬 동기화**

### RDS (`app/backend/db/session.py`, `db/base.py`)
- SQLAlchemy 엔진·세션, `/health/db`에서 `SELECT 1` 연결 확인

### 운영·진입점 (`app/backend/main.py`)
- CORS 적용, `/health`, `/health/db`, `/health/s3`
- `STORAGE_PATH` 디렉터리 생성, `/game` 정적 서빙

### Docker / 문서
- `docker-compose.yml`: 로컬에서 `./storage` 마운트
- `docker-compose.prod.yml`: 프로덕션 env는 GitHub `ENV_FILE` 등으로 주입 권장 주석
- `.env.example`, `docs/AWS_ENV_SETUP.md`

### 의존성
- `pyproject.toml` / `uv.lock`: `boto3`, `sqlalchemy`, `psycopg[binary]`
- RDS URL은 `postgresql+psycopg://` 권장 (드라이버와 스킴 일치)

---

## 테스트

- `ruff` (대상 파일) 통과
- `pytest agent/tests/test_executor_mvp.py` — 로컬에서 `storage` 쓰기 가능하면 4 passed 기대 (일부 CI/샌드박스는 쓰기 제한으로 실패할 수 있음)

---

## 한계 (MVP)

- S3 동기화는 **`llm_service.process_user_input` 경로**에 연결됨 (다른 엔드포인트는 별도 고려)
- Executor `update`는 범용 JSON 패치가 아니라 정의된 도메인 동작 중심
- 외부 MCP 미연동