### PR TITLE
feat: 4단계 Executor 구조화 스텝·레거시 폴백 확장 

### DIFF
--- a/agent/graph/nodes/executor.py
+++ b/agent/graph/nodes/executor.py
@@ -309,11 +309,28 @@ def _supports_legacy_fallback(target_file: str, action: str) -> bool:
     legacy_supported = {
         ("Classes.json", "query"),
         ("Classes.json", "create"),
+        ("Classes.json", "update"),
         ("Actors.json", "query"),
         ("Actors.json", "create"),
         ("Actors.json", "update"),
+        ("Actors.json", "update_actor"),
         ("System.json", "update"),
+        ("System.json", "update_game_title"),
+        ("System.json", "set_variable_name"),
+        ("System.json", "set_switch_name"),
+        ("System.json", "update_starting_position"),
         ("Skills.json", "create"),
+        ("Skills.json", "create_damage"),
+        ("Skills.json", "create_healing"),
+        ("Skills.json", "create_buff"),
+        ("Skills.json", "create_state"),
+        ("Skills.json", "update"),
+        ("Items.json", "create"),
+        ("Items.json", "update"),
+        ("Items.json", "search"),
+        ("Enemies.json", "create"),
+        ("Enemies.json", "update"),
+        ("Enemies.json", "search"),
     }
     return (target_file, action) in legacy_supported
 
@@ -574,6 +591,20 @@ async def _execute_one_structured_step(
                 "timestamp": ts,
             }
 
+        if target_file == "Classes.json" and action == "update":
+            mgr = ClassManager(data_path, f"struct_{sid}")
+            r = await mgr.execute("update", target_info=target_info)
+            step_results[sid] = {**r, "step_id": sid}
+            return {
+                "step_id": sid,
+                "tool_name": "structured_classes_update",
+                "success": bool(r.get("success")),
+                "stdout": r.get("message", ""),
+                "stderr": r.get("error") or "",
+                "structured": True,
+                "timestamp": ts,
+            }
+
         if target_file == "Actors.json" and action == "query":
             mgr = ActorManager(data_path, f"struct_{sid}")
             r = await mgr.execute("query", target_info=target_info)
@@ -624,6 +655,21 @@ async def _execute_one_structured_step(
                 "timestamp": ts,
             }
 
+        if target_file == "Actors.json" and action == "update_actor":
+            mgr = ActorManager(data_path, f"struct_{sid}")
+            # update_actor는 이름 변경 등 일반 속성 수정을 처리한다.
+            r = await mgr.execute("update_general", target_info=target_info)
+            step_results[sid] = {**r, "step_id": sid}
+            return {
+                "step_id": sid,
+                "tool_name": "structured_actors_update_general",
+                "success": bool(r.get("success")),
+                "stdout": r.get("message", ""),
+                "stderr": r.get("error") or "",
+                "structured": True,
+                "timestamp": ts,
+            }
+
         if target_file == "System.json" and action == "update":
             mgr = SystemManager(data_path, f"struct_{sid}")
             # MVP update는 `partyMembers`에 actor를 추가하는 케이스만 지원한다.
@@ -639,26 +685,56 @@ async def _execute_one_structured_step(
                 "timestamp": ts,
             }
 
-        if target_file == "Skills.json" and action == "create":
+        # System의 세부 update 액션들 (MCP 폴백용)
+        if target_file == "System.json" and action in (
+            "update_game_title",
+            "set_variable_name",
+            "set_switch_name",
+            "update_starting_position",
+        ):
+            mgr = SystemManager(data_path, f"struct_{sid}")
+            r = await mgr.execute(action, target_info=target_info)
+            step_results[sid] = {**r, "step_id": sid}
+            return {
+                "step_id": sid,
+                "tool_name": f"structured_system_{action}",
+                "success": bool(r.get("success")),
+                "stdout": r.get("message", ""),
+                "stderr": r.get("error") or "",
+                "structured": True,
+                "timestamp": ts,
+            }
+
+        if target_file == "Skills.json" and action in (
+            "create",
+            "create_damage",
+            "create_healing",
+            "create_buff",
+            "create_state",
+        ):
             mgr = SkillManager(data_path, f"struct_{sid}")
             name = (target_info.get("name") or target_info.get("skill_name") or "").strip()
             if not name:
-                err = "Skills 스텝 create: name 또는 skill_name 필요"
+                err = f"Skills 스텝 {action}: name 또는 skill_name 필요"
                 step_results[sid] = {"success": False, "error": err, "step_id": sid}
                 return {
                     "step_id": sid,
-                    "tool_name": "structured_skills_create",
+                    "tool_name": f"structured_skills_{action}",
                     "success": False,
                     "stderr": err,
                     "structured": True,
                     "timestamp": ts,
                 }
-            extra = {k: target_info[k] for k in ("mpCost", "description") if k in target_info}
+            extra = {
+                k: target_info[k]
+                for k in ("mpCost", "description", "damageFormula", "healFormula")
+                if k in target_info
+            }
             r = await mgr.execute("add", name, **extra)
             step_results[sid] = {**r, "step_id": sid}
             return {
                 "step_id": sid,
-                "tool_name": "structured_skills_create",
+                "tool_name": f"structured_skills_{action}",
                 "success": bool(r.get("success")),
                 "stdout": r.get("message", ""),
                 "stderr": r.get("error") or "",
@@ -666,6 +742,95 @@ async def _execute_one_structured_step(
                 "structured": True,
                 "timestamp": ts,
             }
+
+        if target_file == "Skills.json" and action == "update":
+            mgr = SkillManager(data_path, f"struct_{sid}")
+            skill_id = target_info.get("skill_id") or target_info.get("skillId")
+            updates = target_info.get("updates")
+            if skill_id is None or not isinstance(updates, dict):
+                err = "Skills update에는 skill_id와 updates가 필요합니다."
+                step_results[sid] = {"success": False, "error": err, "step_id": sid}
+                return {
+                    "step_id": sid,
+                    "tool_name": "structured_skills_update",
+                    "success": False,
+                    "stderr": err,
+                    "structured": True,
+                    "timestamp": ts,
+                }
+            # SkillManager의 update 액션 사용 (skill_id 기반)
+            r = await mgr.execute("update", f"skill_{skill_id}", target_info=target_info)
+            step_results[sid] = {**r, "step_id": sid}
+            return {
+                "step_id": sid,
+                "tool_name": "structured_skills_update",
+                "success": bool(r.get("success")),
+                "stdout": r.get("message", ""),
+                "stderr": r.get("error") or "",
+                "modified_files": r.get("modified_files"),
+                "structured": True,
+                "timestamp": ts,
+            }
+
+        # Items/Enemies는 dispatcher 함수를 통해 처리 (매니저가 없음)
+        if target_file in ("Items.json", "Enemies.json") and action in (
+            "create",
+            "update",
+            "search",
+        ):
+            from app.backend.services.json_modify_tools.dispatcher import run_enemies, run_items
+
+            dispatcher_map = {
+                "Items.json": run_items,
+                "Enemies.json": run_enemies,
+            }
+
+            dispatcher_func = dispatcher_map[target_file]
+
+            # target_info에서 적절한 자연어 입력 구성
+            name = (
+                target_info.get("name")
+                or target_info.get("item_name")
+                or target_info.get("enemy_name")
+                or ""
+            )
+
+            if action == "create":
+                user_input = f"{name} 추가해줘"
+            elif action == "update":
+                updates = target_info.get("updates", {})
+                if isinstance(updates, dict) and updates:
+                    update_desc = ", ".join(f"{k}={v}" for k, v in updates.items())
+                    user_input = f"{name} {update_desc}로 수정해줘"
+                else:
+                    user_input = f"{name} 수정해줘"
+            else:  # search
+                user_input = f"{name} 찾아줘"
+
+            try:
+                r = await asyncio.to_thread(dispatcher_func, user_input)
+                step_results[sid] = {**r, "step_id": sid}
+                return {
+                    "step_id": sid,
+                    "tool_name": f"structured_{target_file.replace('.json', '').lower()}_{action}",
+                    "success": bool(r.get("success", False)),
+                    "stdout": r.get("stdout", ""),
+                    "stderr": r.get("stderr", ""),
+                    "modified_files": [target_file],
+                    "structured": True,
+                    "timestamp": ts,
+                }
+            except Exception as e:
+                err = f"Dispatcher 호출 실패: {e}"
+                step_results[sid] = {"success": False, "error": err, "step_id": sid}
+                return {
+                    "step_id": sid,
+                    "tool_name": f"structured_{target_file.replace('.json', '').lower()}_{action}",
+                    "success": False,
+                    "stderr": err,
+                    "structured": True,
+                    "timestamp": ts,
+                }
 
         # 위 조건에 없는 target/action 조합은 현재 MVP에서 아직 구현되지 않았다는 뜻이다.
         # (MCP 핸들러 없음 + 레거시 매니저 핸들러 없음)인 "정의되지 않은 액션"이다.

--- a/agent/tests/test_executor_mvp.py
+++ b/agent/tests/test_executor_mvp.py
@@ -607,9 +607,9 @@ async def test_mcp_failure_abort_policy_system_update_game_title(monkeypatch):
 
     result = await executor(state)
     log = result["changes_log"][0]
-    assert log["tool_name"] == "update_game_title"
-    assert log["success"] is False
-    assert "[MCP_ABORT_NO_FALLBACK]" in (log.get("stderr") or "")
+    assert log["tool_name"] == "structured_system_update_game_title"
+    assert log["success"] is True  # 이제 레거시 폴백으로 성공
+    # MCP 실패 후 레거시로 성공했으므로 MCP_ABORT_NO_FALLBACK 에러는 없음
 
 
 @pytest.mark.asyncio

--- a/app/backend/services/json_modify_tools/managers/actor_manager.py
+++ b/app/backend/services/json_modify_tools/managers/actor_manager.py
@@ -21,6 +21,26 @@ class ActorManager(BaseManager):
         return self.data_path / "Actors.json"
 
     async def execute(self, action: str, **kwargs) -> dict[str, Any]:
+        # Executor 구조화 스텝 / MCP 폴백: ID·필드 단위 일반 수정 (update_actor와 동일 역할의 레거시)
+        if action == "update_general":
+            ti = kwargs.get("target_info", {})
+            if isinstance(ti, dict):
+                actor_id = ti.get("actor_id") or ti.get("actorId")
+                updates = ti.get("updates")
+                if actor_id is None:
+                    return {
+                        "success": False,
+                        "error": "update_general에는 actor_id가 필요합니다.",
+                        "category": "actors",
+                    }
+                if not isinstance(updates, dict):
+                    return {
+                        "success": False,
+                        "error": "update_general에는 updates dict가 필요합니다.",
+                        "category": "actors",
+                    }
+                return self._handle_update_general(actor_id, updates)
+
         actor_name = (kwargs.get("actor_name") or "").strip()
         if not actor_name:
             ti = kwargs.get("target_info")
@@ -247,5 +267,102 @@ class ActorManager(BaseManager):
             "class_id": int(resolved_class_id),
             "modified_files": ["Actors.json"],
             "message": f"액터 '{actor_name}' classId를 {int(resolved_class_id)}로 수정",
+            "category": "actors",
+        }
+
+    def _handle_update_general(self, actor_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Actors.json에서 actor_id 인덱스 행의 허용 필드만 갱신한다.
+
+        RPG MZ Actors 배열 규칙(0번 null)을 따르며, 지정 키만 타입에 맞게 덮어쓴다.
+        """
+        try:
+            actor_id = int(actor_id)
+        except (TypeError, ValueError):
+            return {
+                "success": False,
+                "error": f"잘못된 actor_id: {actor_id}",
+                "category": "actors",
+            }
+
+        data = self.load_json_data()
+        if not isinstance(data, list) or actor_id < 1 or actor_id >= len(data):
+            return {
+                "success": False,
+                "error": f"actor_id {actor_id}는 유효하지 않습니다.",
+                "category": "actors",
+            }
+
+        actor = data[actor_id]
+        if actor is None:
+            return {
+                "success": False,
+                "error": f"actor_id {actor_id}에 액터가 없습니다.",
+                "category": "actors",
+            }
+
+        # RPG MZ 액터 객체에서 안전하게 손댈 수 있는 키만 허용 (나머지는 무시)
+        updatable_fields = {
+            "name": str,
+            "nickname": str,
+            "profile": str,
+            "classId": int,
+            "characterName": str,
+            "characterIndex": int,
+            "faceName": str,
+            "faceIndex": int,
+            "initialLevel": int,
+            "expParams": list,
+            "params": list,
+        }
+
+        updated_fields = []
+        original_values = {}
+
+        for field, value in updates.items():
+            if field not in updatable_fields:
+                logger.warning("[%s] 지원하지 않는 필드 무시: %s", self.operation_id, field)
+                continue
+
+            expected_type = updatable_fields[field]
+            original_values[field] = actor.get(field)
+
+            try:
+                # 타입 변환
+                if expected_type is int:
+                    actor[field] = int(value)
+                elif expected_type is str:
+                    actor[field] = str(value)
+                elif expected_type is list:
+                    if isinstance(value, list):
+                        actor[field] = value
+                    else:
+                        logger.warning("[%s] 리스트가 아닌 값은 무시: %s", self.operation_id, field)
+                        continue
+                else:
+                    actor[field] = value
+
+                updated_fields.append(field)
+            except (TypeError, ValueError) as e:
+                logger.warning("[%s] 필드 %s 변환 실패: %s", self.operation_id, field, e)
+                continue
+
+        if not updated_fields:
+            return {
+                "success": False,
+                "error": "업데이트할 유효한 필드가 없습니다.",
+                "category": "actors",
+            }
+
+        # 파일 저장
+        self.save_json_data(data)
+
+        return {
+            "success": True,
+            "action": "update_general",
+            "actor_id": actor_id,
+            "updated_fields": updated_fields,
+            "original_values": original_values,
+            "message": f"액터 {actor_id}의 {len(updated_fields)}개 속성을 업데이트했습니다: {', '.join(updated_fields)}",
+            "modified_files": ["Actors.json"],
             "category": "actors",
         }

--- a/app/backend/services/json_modify_tools/managers/class_manager.py
+++ b/app/backend/services/json_modify_tools/managers/class_manager.py
@@ -15,7 +15,21 @@ class ClassManager(BaseManager):
         return self.data_path / "Classes.json"
 
     async def execute(self, action: str, **kwargs) -> dict[str, Any]:
-        # Structured step에서 넘어오는 값을 기반으로 query/create를 분기한다.
+        # update는 class_id+updates만 사용 (이름 없이 호출됨 — Executor 구조화·MCP 폴백)
+        if action == "update":
+            ti = kwargs.get("target_info", {})
+            if isinstance(ti, dict):
+                class_id = ti.get("class_id") or ti.get("classId")
+                updates = ti.get("updates")
+                if class_id is not None and isinstance(updates, dict):
+                    return self._handle_update_general(class_id, updates)
+            return {
+                "success": False,
+                "error": "update 액션에는 target_info에 class_id와 updates가 필요합니다.",
+                "category": "classes",
+            }
+
+        # query / create: 클래스 이름 기반
         class_name = (kwargs.get("class_name") or "").strip()
         if not class_name:
             ti = kwargs.get("target_info")
@@ -117,5 +131,89 @@ class ClassManager(BaseManager):
             "class_name": class_name,
             "modified_files": ["Classes.json"],
             "message": f"클래스 '{class_name}' 생성됨 (id={new_id})",
+            "category": "classes",
+        }
+
+    def _handle_update_general(self, class_id: int, updates: dict[str, Any]) -> dict[str, Any]:
+        """Classes.json에서 class_id 인덱스 행의 허용 필드만 갱신한다 (이름 기반 create/query와 별개)."""
+        try:
+            class_id = int(class_id)
+        except (TypeError, ValueError):
+            return {
+                "success": False,
+                "error": f"잘못된 class_id: {class_id}",
+                "category": "classes",
+            }
+
+        data = self.load_json_data()
+        if not isinstance(data, list) or class_id < 1 or class_id >= len(data):
+            return {
+                "success": False,
+                "error": f"class_id {class_id}는 유효하지 않습니다.",
+                "category": "classes",
+            }
+
+        class_obj = data[class_id]
+        if class_obj is None:
+            return {
+                "success": False,
+                "error": f"class_id {class_id}에 클래스가 없습니다.",
+                "category": "classes",
+            }
+
+        # 허용 키만 반영 (미지정 필드는 건너뜀)
+        updatable_fields = {
+            "name": str,
+            "params": list,
+            "expParams": list,
+            "learnings": list,
+            "characterName": str,
+            "characterIndex": int,
+            "faceName": str,
+            "faceIndex": int,
+            "note": str,
+        }
+
+        updated_fields = []
+        original_values = {}
+
+        for field, value in updates.items():
+            if field not in updatable_fields:
+                continue
+
+            expected_type = updatable_fields[field]
+            original_values[field] = class_obj.get(field)
+
+            try:
+                if expected_type is int:
+                    class_obj[field] = int(value)
+                elif expected_type is str:
+                    class_obj[field] = str(value)
+                elif expected_type is list:
+                    if isinstance(value, list):
+                        class_obj[field] = value
+                else:
+                    class_obj[field] = value
+
+                updated_fields.append(field)
+            except (TypeError, ValueError):
+                continue
+
+        if not updated_fields:
+            return {
+                "success": False,
+                "error": "업데이트할 유효한 필드가 없습니다.",
+                "category": "classes",
+            }
+
+        self.save_json_data(data)
+
+        return {
+            "success": True,
+            "action": "update_general",
+            "class_id": class_id,
+            "updated_fields": updated_fields,
+            "message": f"클래스 {class_id}의 {len(updated_fields)}개 속성을 업데이트했습니다: {', '.join(updated_fields)}",
+            "modified_files": ["Classes.json"],
             "category": "classes",
         }

--- a/app/backend/services/json_modify_tools/managers/system_manager.py
+++ b/app/backend/services/json_modify_tools/managers/system_manager.py
@@ -14,12 +14,31 @@ class SystemManager(BaseManager):
         return self.data_path / "System.json"
 
     async def execute(self, action: str, **kwargs) -> dict[str, Any]:
+        # 구조화 플랜은 target_info에 snake_case/camelCase 혼용 가능
+        ti = kwargs.get("target_info") if isinstance(kwargs.get("target_info"), dict) else {}
+
         if action == "add_party_member":
             # Planner step: System.json + update(action_type="update")
             # 여기서는 그 의미를 "partyMembers에 actor 추가"로 해석한다.
-            ti = kwargs.get("target_info") if isinstance(kwargs.get("target_info"), dict) else {}
             actor_name = (ti.get("actor_name") or kwargs.get("actor_name") or "").strip()
             return self._handle_add_party_member(actor_name)
+        # 아래 네 액션은 MCP(System.json 툴)와 동일 의미 — MCP 비활성/실패 시 레거시로 수행
+        if action == "update_game_title":
+            title = ti.get("title") or ti.get("game_title")
+            return self._handle_update_game_title(title)
+        if action == "set_variable_name":
+            variable_id = ti.get("variable_id") or ti.get("variableId")
+            name = ti.get("name")
+            return self._handle_set_variable_name(variable_id, name)
+        if action == "set_switch_name":
+            switch_id = ti.get("switch_id") or ti.get("switchId")
+            name = ti.get("name")
+            return self._handle_set_switch_name(switch_id, name)
+        if action == "update_starting_position":
+            map_id = ti.get("map_id") or ti.get("mapId")
+            x = ti.get("x")
+            y = ti.get("y")
+            return self._handle_update_starting_position(map_id, x, y)
         return {
             "success": False,
             "error": f"MVP에서 지원하지 않는 액션: {action}",
@@ -92,6 +111,176 @@ class SystemManager(BaseManager):
             "actor_id": actor_id,
             "actor_name": actor_name,
             "message": f"액터 '{actor_name}'(id={actor_id})를 partyMembers에 추가",
+            "modified_files": ["System.json"],
+            "category": "system",
+        }
+
+    def _handle_update_game_title(self, title: str) -> dict[str, Any]:
+        """System.gameTitle 갱신 (MCP update_game_title 대응)."""
+        if not title:
+            return {
+                "success": False,
+                "error": "게임 타이틀이 비어있습니다.",
+                "category": "system",
+            }
+
+        system = self.load_json_data()
+        if not isinstance(system, dict):
+            return {
+                "success": False,
+                "error": "System.json 형식이 예상과 다릅니다.",
+                "category": "system",
+            }
+
+        old_title = system.get("gameTitle", "")
+        system["gameTitle"] = str(title)
+        self.save_json_data(system)
+
+        return {
+            "success": True,
+            "action": "update_game_title",
+            "old_title": old_title,
+            "new_title": title,
+            "message": f"게임 타이틀을 '{old_title}' → '{title}'로 변경했습니다.",
+            "modified_files": ["System.json"],
+            "category": "system",
+        }
+
+    def _handle_set_variable_name(self, variable_id: int, name: str) -> dict[str, Any]:
+        """variables[variable_id]에 표시 이름 저장; 부족하면 배열 확장 (MCP set_variable_name 대응)."""
+        try:
+            variable_id = int(variable_id)
+        except (TypeError, ValueError):
+            return {
+                "success": False,
+                "error": f"잘못된 variable_id: {variable_id}",
+                "category": "system",
+            }
+
+        if not name:
+            return {
+                "success": False,
+                "error": "변수 이름이 비어있습니다.",
+                "category": "system",
+            }
+
+        system = self.load_json_data()
+        if not isinstance(system, dict):
+            return {
+                "success": False,
+                "error": "System.json 형식이 예상과 다릅니다.",
+                "category": "system",
+            }
+
+        variables = system.get("variables", [])
+        if not isinstance(variables, list):
+            variables = []
+            system["variables"] = variables
+
+        # MZ는 인덱스=변수 ID; 짧으면 빈 문자열로 패딩
+        while len(variables) <= variable_id:
+            variables.append("")
+
+        old_name = variables[variable_id]
+        variables[variable_id] = str(name)
+        self.save_json_data(system)
+
+        return {
+            "success": True,
+            "action": "set_variable_name",
+            "variable_id": variable_id,
+            "old_name": old_name,
+            "new_name": name,
+            "message": f"변수 {variable_id} 이름을 '{old_name}' → '{name}'로 설정했습니다.",
+            "modified_files": ["System.json"],
+            "category": "system",
+        }
+
+    def _handle_set_switch_name(self, switch_id: int, name: str) -> dict[str, Any]:
+        """switches[switch_id]에 표시 이름 저장; 부족하면 배열 확장 (MCP set_switch_name 대응)."""
+        try:
+            switch_id = int(switch_id)
+        except (TypeError, ValueError):
+            return {
+                "success": False,
+                "error": f"잘못된 switch_id: {switch_id}",
+                "category": "system",
+            }
+
+        if not name:
+            return {
+                "success": False,
+                "error": "스위치 이름이 비어있습니다.",
+                "category": "system",
+            }
+
+        system = self.load_json_data()
+        if not isinstance(system, dict):
+            return {
+                "success": False,
+                "error": "System.json 형식이 예상과 다릅니다.",
+                "category": "system",
+            }
+
+        switches = system.get("switches", [])
+        if not isinstance(switches, list):
+            switches = []
+            system["switches"] = switches
+
+        while len(switches) <= switch_id:
+            switches.append("")
+
+        old_name = switches[switch_id]
+        switches[switch_id] = str(name)
+        self.save_json_data(system)
+
+        return {
+            "success": True,
+            "action": "set_switch_name",
+            "switch_id": switch_id,
+            "old_name": old_name,
+            "new_name": name,
+            "message": f"스위치 {switch_id} 이름을 '{old_name}' → '{name}'로 설정했습니다.",
+            "modified_files": ["System.json"],
+            "category": "system",
+        }
+
+    def _handle_update_starting_position(self, map_id: int, x: int, y: int) -> dict[str, Any]:
+        """startMapId / startX / startY 설정 (MCP update_starting_position 대응)."""
+        try:
+            map_id = int(map_id)
+            x = int(x)
+            y = int(y)
+        except (TypeError, ValueError):
+            return {
+                "success": False,
+                "error": "map_id, x, y는 모두 정수여야 합니다.",
+                "category": "system",
+            }
+
+        system = self.load_json_data()
+        if not isinstance(system, dict):
+            return {
+                "success": False,
+                "error": "System.json 형식이 예상과 다릅니다.",
+                "category": "system",
+            }
+
+        old_map = system.get("startMapId", 1)
+        old_x = system.get("startX", 0)
+        old_y = system.get("startY", 0)
+
+        system["startMapId"] = map_id
+        system["startX"] = x
+        system["startY"] = y
+        self.save_json_data(system)
+
+        return {
+            "success": True,
+            "action": "update_starting_position",
+            "old_position": {"map": old_map, "x": old_x, "y": old_y},
+            "new_position": {"map": map_id, "x": x, "y": y},
+            "message": f"시작 위치를 맵 {old_map}({old_x},{old_y}) → 맵 {map_id}({x},{y})로 변경했습니다.",
             "modified_files": ["System.json"],
             "category": "system",
         }


### PR DESCRIPTION
# Re:Verse 4단계 Executor — stdio MCP 연동 및 구조화 execution_plan 

## 1. 전체 그래프에서의 위치

LangGraph 흐름

- **START → router** → (범위 외 등이면 END)
- **definition** → (파라미터 부족이면 END)
- **planner (3단계)** → `execution_plan` 생성
- **executor (4단계)** → 디스크의 RPG Maker `data/` JSON 수정, `changes_log`·백업·스냅샷 등 반환
- **validator (5단계)** → 검증 실패 시 `retry_count` 조건에 따라 다시 **executor**
- **synthesizer → END**

공유 상태(`AgentState`)에서 3단계는 `execution_plan`을, 4단계는 `current_game_state` / `modified_game_state` / `changes_log` / `backup_paths` 등을 채운다
(프로젝트 설정에 따라 스냅샷이 **파일 경로 맵**인지 **인라인 dict**인지는 `state.py`·Validator 구현을 기준).

---

## 2. 데이터·환경

- 게임 JSON 경로: **`STORAGE_PATH`** 설정 → `{STORAGE_PATH}/{game_id}/data/` (예: `Actors.json`, `Skills.json`).
- **MCP(백엔드 stdio)** 
  - **`MCP_ENABLED`**: MCP 분기 시도 여부
  - **`MCP_NODE_SERVER_PATH`**, **`MCP_COMMAND` / `MCP_ARGS`**, **`MCP_CWD`**, **`MCP_ENV_JSON`**
  - **`MCP_TIMEOUT`**, **`MCP_PATH_ARG_NAME`** (게임 `data/` 경로를 넣는 인자 키, 서버 스펙과 맞출 것)

---

## 3. 목적

- **3단계 Planner** 출력은 `action_type`·필드 이름(snake_case/camelCase)·의미
- **4단계 Executor**에서 그 편차를 **한 번 흡수**
  - **MCP 사용 가능**이면 k4zuki RPG Maker MZ Node 서버의 `call_tool`을 우선 사용.
  - **비활성·실패** 시 **Python 매니저·dispatcher**로 같은 의미를 수행할 수 있으면 폴백, 없으면 **명시적 중단**으로 잘못된 침묵 성공을 막는다.

---

## 4. MCP 연동 (`agent/mcp_toolbox.py`)

| 구성 | 역할 | 왜 필요한가 |
|------|------|-------------|
| `is_mcp_enabled` | MCP 분기 on/off | 로컬/운영에서 동일 코드로 MCP 유무 전환 |
| `build_stdio_server_parameters` | stdio 서버 실행 파라미터 조립 | MCP SDK가 요구하는 형식으로 환경을 매핑 |
| `get_mcp_server_args`, `get_mcp_stdio_env` | 인자·자식 프로세스 env | Docker/로컬 실행 차이 흡수 |
| `_is_path_under_storage_root` | `data/` 경로가 허용 루트 아래인지 | 임의 경로 조작 완화 |
| `call_mcp_tool` | `call_tool` + **고정 형태** 반환 | Executor가 `success` / `data` / `modified_files` / `error`만 보면 됨 |
| `resolve_game_data_path`, `resolve_storage_root` | 경로 헬퍼 | 백엔드 `game_paths`와 동일 기준 유지 |

---

## 5. 4단계 Executor — 두 갈래

`executor()` 진입 후:

1. `retry_count`, 빈 플랜 등 검증
2. `data_path = get_game_data_path(game_id)` 계산
3. **`_is_structured_execution_plan`**: 첫 행에 `step_id`, `action_type`, `target_file`이 있으면 **구조화 엔진** (`_executor_structured`)
4. 아니면 **레거시 MVP**: LLM 번역 → `TOOL_MAP` / `SkillManager` / dispatcher

### 5.1 구조화 경로 (`_executor_structured`)

- **`_topological_sort_steps`**: `depends_on`으로 실행 순서 보장(순환 등이면 `step_id` 순 폴백).
- **`_collect_structured_target_files`**: 스냅샷·백업 대상 JSON 목록.
- 실행 전/후 스냅샷·백업, 루프에서 각 스텝마다 **`_should_execute_structured_step`**으로 스킵 여부 판단 후 **`_execute_one_structured_step`** 호출.
- 결과: `changes_log`, `backup_paths`, `current_game_state` / `modified_game_state`(프로젝트 계약에 따름).

### 5.2 한 스텝 (`_execute_one_structured_step`)

- **`_normalize_structured_action`**: Planner의 넓은 `action_type`을 MCP/레거시가 이해하는 구체 액션으로 통일  
  (예: Actors `update`+`updates`+ID → `update_actor`; System 광의 `update` → `update_game_title` / `set_variable_name` 등).
- **MCP**: `is_mcp_enabled()`이고 `(target_file, action)`이 **`MCP_TOOL_MAP`**에 있고 stdio 설정이 있으면  
  **`_normalize_mcp_arguments`**로 인자 정규화 후 **`call_mcp_tool`** (동일 `game_id`는 **`game_locks`**로 직렬화).
- **성공**: `changes_log` 항목 반환.
- **실패**: **`_supports_legacy_fallback`**이 True면 레거시 매니저/dispatcher; False면 **`MCP_ABORT_NO_FALLBACK`** 등으로 중단.
- MCP에 없는 조합은 매핑·레거시 분기 밖이면 **`UNSUPPORTED_STRUCTURED_STEP`** 등 표준 에러 문자열.

### 5.3 맵·정책·에러 포맷 (`executor.py` 핵심 부품)

| 이름 | 역할 |
|------|------|
| `MCP_TOOL_MAP` | `(target_file, action)` → MCP 툴 이름·백업 힌트 (서버 `list_tools`에 맞춤; Classes/Enemies 등 서버에 없으면 맵에도 없을 수 있음) |
| `_normalize_mcp_arguments` | `target_info` → MCP 스키마(camelCase, ID 캐스팅, `updates` 구성) |
| `_normalize_structured_action` | Planner 편차 흡수 |
| `_supports_legacy_fallback` | MCP 실패 시 레거시 허용 여부 — **구현된 레거시 분기와 1:1 화이트리스트** |
| `_structured_error` | `[CODE] target_file=… action=…` 고정 포맷 — 로그·집계·재시도 파싱용 |
| `_as_int` | ID 정수화 시도 |

레거시 확장 예: **Classes `update`**, **Actors `update_actor` → ActorManager `update_general`**, **System 세부 액션 → SystemManager**, **Skills** 변형 생성·`update` → **SkillManager**, **Items/Enemies** → **`run_items` / `run_enemies`**(자연어 조합 등 MVP식).

### 5.4 비구조화 경로

- `execution_plan`이 옛 포맷이면 `_translate_execution_plan_mvp` → `edit_*` 툴과 dispatcher — **기존 파이프라인 호환**.

---

## 6. JSON 매니저 (`app/backend/.../managers/`)

MCP가 꺼져 있거나 실패했을 때 **동일 게임 데이터 의미**를 디스크에 반영.

- **ActorManager**: `update_general` — `actor_id` + `updates` (MCP `update_actor`와 대응).
- **ClassManager**: `update` — `class_id` + `updates`; Executor는 이름 없이 호출하므로 **`update` 분기가 `class_name` 검사보다 앞**에 와야 함.
- **SystemManager**: 타이틀, 변수/스위치 이름, 시작 위치 등 — MCP System 툴과 동일 의미의 레거시.
- **SkillManager**: 구조화 스텝에서 스킬 생성·갱신 폴백.

Executor 안에 RPG MZ 포맷 전부를 넣지 않고 **도메인별 매니저**로 나눈 이유는 테스트·재사용·가독성 때문

---

## 7. 테스트·검증 (`agent/tests/test_executor_mvp.py` 등)

- MCP를 **monkeypatch**로 흉내 내어 **툴 이름·인자**가 기대와 맞는지 검증.
- **MCP 실패 정책**: 폴백이 생기면 테스트 기대도 바뀜(예: `update_game_title`이 레거시로 성공하면 중단 메시지 대신 성공).
- 선택: `check_mcp_smoke`, ruff, pytest `-k` 필터 등은 README/배포 문서와 맞춰 실행.

---

## 8. 관련 파일 한눈에

| 영역 | 파일 |
|------|------|
| 그래프 | `agent/graph/workflow.py`, `agent/graph/state.py` |
| 4단계 | `agent/graph/nodes/executor.py` |
| MCP 클라이언트 | `agent/mcp_toolbox.py` |
| 게임 경로 | `app/backend/core/game_paths.py` |
| 레거시 수정 | `managers/actor_manager.py`, `class_manager.py`, `system_manager.py`, `skill_manager.py`, `dispatcher` |
| 테스트 | `agent/tests/test_executor_mvp.py` |
| 배포·MCP 경로 | `docker/backend.Dockerfile`, `.env.example`, `README-DEPLOYMENT.md`|

---

## 9. 기대 효과 (한 줄씩)

- Planner 출력 편차를 4단계에서 끊어 **플랜–실행 연결 안정화**.
- MCP 우선 + **명시적 폴백/중단**으로 운영 시 행동 예측 가능.
- 표준 에러 문자열·`changes_log`로 **디버깅·로깅** 용이.
- Validator·재시도·롤백과 맞물리도록 **상태 필드 계약** 유지.