### PR TITLE
fix: validator step 검증 추가, base_game 맞춰 스키마 수정

### DIFF
--- a/agent/graph/nodes/validator.py
+++ b/agent/graph/nodes/validator.py
@@ -10,8 +10,10 @@ from typing import Any
 
 from pydantic import BaseModel, Field, ValidationError
 
+from agent.core.llm_client import invoke_llm
 from agent.graph.state import AgentState
 from agent.graph.utils.game_state_json import load_snapshot_payload
+from agent.prompts.validator_prompt import build_prompt as build_validator_prompt
 from agent.schemas.actors import ActorsFile
 from agent.schemas.animations import AnimationsFile
 from agent.schemas.armors import ArmorsFile
@@ -64,6 +66,11 @@ class ValidatorOutput(BaseModel):
     validation_summary: str
     success: bool
     retry_count: int | None = None
+
+
+class StepValidationLLMResult(BaseModel):
+    is_match: bool
+    reasoning: str
 
 
 def to_jsonable(value: Any) -> Any:
@@ -141,8 +148,8 @@ def build_validation_summary(validation_results: list[FileValidationResult]) -> 
     return f"총 {len(validation_results)}개 파일 중 {failed_count}개 파일 검증에 실패했습니다."
 
 
-def build_state_error(message: str, retry_count: int | None = None) -> ValidatorOutput:
-    logger.warning("[Validator] 조기 종료: %s (retry=%s)", message, retry_count)
+def build_state_error(message: str) -> ValidatorOutput:
+    logger.warning("[Validator] 조기 종료: %s", message)
     validation_results = [
         build_file_result(
             target="state",
@@ -154,15 +161,22 @@ def build_state_error(message: str, retry_count: int | None = None) -> Validator
         validation_results=validation_results,
         validation_summary=message,
         success=False,
-        retry_count=retry_count,
     )
 
 
 def extract_validation_inputs(
     state: AgentState,
-) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]], dict[str, str], int]:
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    dict[str, str],
+    int,
+]:
     current_game_state = state.get("current_game_state", {})
     modified_game_state = state.get("modified_game_state", {})
+    execution_plan = state.get("execution_plan", [])
     changes_log = state.get("changes_log", [])
     backup_paths = state.get("backup_paths", {})
     retry_count = state.get("retry_count", 0)
@@ -171,8 +185,12 @@ def extract_validation_inputs(
         current_game_state = {}
     if not isinstance(modified_game_state, dict):
         modified_game_state = {}
+    if not isinstance(execution_plan, list):
+        execution_plan = []
     if not isinstance(changes_log, list):
         changes_log = []
+    execution_plan = [item for item in execution_plan if isinstance(item, dict)]
+    changes_log = [item for item in changes_log if isinstance(item, dict)]
     if not isinstance(backup_paths, dict):
         backup_paths = {}
     try:
@@ -180,7 +198,14 @@ def extract_validation_inputs(
     except (TypeError, ValueError):
         retry_count = 0
 
-    return current_game_state, modified_game_state, changes_log, backup_paths, retry_count
+    return (
+        current_game_state,
+        modified_game_state,
+        execution_plan,
+        changes_log,
+        backup_paths,
+        retry_count,
+    )
 
 
 def load_validation_payload(file_name: str, value: Any) -> tuple[Any, list[dict[str, Any]]]:
@@ -217,6 +242,201 @@ def summarize_modified_files(
 
         unchanged_count += 1
     return detected_count, unchanged_count
+
+
+def select_validation_targets(
+    modified_entries: dict[str, tuple[Any, list[dict[str, Any]]]],
+) -> list[tuple[str, Any, list[dict[str, Any]]]]:
+    return [
+        (file_name, payload, payload_errors)
+        for file_name, (payload, payload_errors) in modified_entries.items()
+    ]
+
+
+def calculate_schema_success(validation_results: list[FileValidationResult]) -> bool:
+    return all(item.success for item in validation_results)
+
+
+def calculate_final_success(schema_success: bool, step_success: bool) -> bool:
+    return schema_success and step_success
+
+
+def calculate_retry_count(retry_count: int, success: bool) -> int | None:
+    return None if success else retry_count + 1
+
+
+def finalize_output(result: ValidatorOutput) -> dict[str, Any]:
+    validated_result = ValidatorOutput.model_validate(result.model_dump(mode="python"))
+    return validated_result.model_dump(mode="json", exclude_none=True)
+
+
+def _coerce_step_id(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def build_step_id_map(entries: list[dict[str, Any]], source: str) -> dict[int, dict[str, Any]]:
+    by_id: dict[int, dict[str, Any]] = {}
+    for entry in entries:
+        step_id = _coerce_step_id(entry.get("step_id"))
+        if step_id is None:
+            logger.warning("[Validator] %s step_id 누락 또는 형식 오류: %s", source, entry)
+            continue
+        if step_id in by_id:
+            logger.warning("[Validator] %s duplicate step_id=%s", source, step_id)
+            continue
+        by_id[step_id] = entry
+    return by_id
+
+
+def build_step_failure_result(step_id: int, message: str) -> FileValidationResult:
+    return build_file_result(
+        target=f"step:{step_id}",
+        success=False,
+        errors=[{"loc": "$", "msg": message}],
+    )
+
+
+def _normalize_modified_files(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _build_step_validation_prompt_state(
+    planner_step: dict[str, Any],
+    executor_log: dict[str, Any],
+) -> dict[str, Any]:
+    planner_step_id = _coerce_step_id(planner_step.get("step_id")) or -1
+    executor_step_id = _coerce_step_id(executor_log.get("step_id")) or -1
+    return {
+        "_validator_prompt_mode": "step_validation",
+        "planner_step": {
+            "step_id": planner_step_id,
+            "description": str(planner_step.get("description", "")),
+            "action_type": str(planner_step.get("action_type", "")),
+            "target_file": str(planner_step.get("target_file", "")),
+        },
+        "executor_log": {
+            "step_id": executor_step_id,
+            "tool_name": str(executor_log.get("tool_name", "")),
+            "success": bool(executor_log.get("success")),
+            "modified_files": _normalize_modified_files(executor_log.get("modified_files")),
+        },
+    }
+
+
+async def judge_step_match_with_llm(
+    planner_step: dict[str, Any],
+    executor_log: dict[str, Any],
+) -> StepValidationLLMResult:
+    step_id = _coerce_step_id(planner_step.get("step_id")) or -1
+    messages = build_validator_prompt(
+        _build_step_validation_prompt_state(planner_step, executor_log)
+    )
+
+    try:
+        result = await invoke_llm(messages, structured_output=StepValidationLLMResult)
+    except Exception as error:
+        logger.warning("[Validator] step validation LLM 실패: step_id=%s err=%s", step_id, error)
+        return StepValidationLLMResult(
+            is_match=False,
+            reasoning=f"step validation LLM error: {error}",
+        )
+
+    if isinstance(result, StepValidationLLMResult):
+        return result
+    return StepValidationLLMResult.model_validate(result)
+
+
+async def validate_execution_steps(
+    execution_plan: list[dict[str, Any]],
+    changes_log: list[dict[str, Any]],
+) -> tuple[list[FileValidationResult], bool]:
+    planner_steps = build_step_id_map(execution_plan, "planner step")
+    executor_candidates = [entry for entry in changes_log if entry.get("step_id") is not None]
+    executor_logs = build_step_id_map(executor_candidates, "executor log")
+    failures: list[FileValidationResult] = []
+    extra_step_ids = sorted(set(executor_logs) - set(planner_steps))
+
+    logger.info(
+        "[Validator] step 검증 시작: planner_steps=%d, executor_candidates=%d, executor_steps=%d",
+        len(planner_steps),
+        len(executor_candidates),
+        len(executor_logs),
+    )
+    if extra_step_ids:
+        logger.info("[Validator] step 검증 보류: extra executor steps=%s", extra_step_ids)
+
+    for step_id in sorted(planner_steps):
+        planner_step = planner_steps[step_id]
+        executor_log = executor_logs.get(step_id)
+        logger.info(
+            "[Validator] step 검증: step_id=%d, action=%s, target=%s",
+            step_id,
+            str(planner_step.get("action_type", "")),
+            str(planner_step.get("target_file", "")),
+        )
+        if executor_log is None:
+            logger.warning(
+                "[Validator] step 검증 실패: step_id=%d reason=missing executor log",
+                step_id,
+            )
+            failures.append(
+                build_step_failure_result(
+                    step_id,
+                    f"planner step {step_id}에 대응하는 executor log가 changes_log에 없습니다.",
+                )
+            )
+            continue
+
+        if executor_log.get("success") is not True:
+            tool_name = str(executor_log.get("tool_name", ""))
+            reason = str(
+                executor_log.get("stderr")
+                or executor_log.get("error")
+                or executor_log.get("skip_reason")
+                or "executor step failed"
+            )
+            logger.warning(
+                "[Validator] step 검증 실패: step_id=%d tool=%s reason=%s",
+                step_id,
+                tool_name,
+                reason,
+            )
+            failures.append(
+                build_step_failure_result(
+                    step_id,
+                    f"executor step {step_id} failed: tool={tool_name}, reason={reason}",
+                )
+            )
+            continue
+
+        llm_result = await judge_step_match_with_llm(planner_step, executor_log)
+        if not llm_result.is_match:
+            logger.warning(
+                "[Validator] step 검증 실패: step_id=%d tool=%s reason=%s",
+                step_id,
+                str(executor_log.get("tool_name", "")),
+                llm_result.reasoning,
+            )
+            failures.append(build_step_failure_result(step_id, llm_result.reasoning))
+            continue
+
+        logger.info(
+            "[Validator] step 검증 통과: step_id=%d tool=%s",
+            step_id,
+            str(executor_log.get("tool_name", "")),
+        )
+
+    logger.info(
+        "[Validator] step 검증 종료: success=%s, failed=%d",
+        not failures,
+        len(failures),
+    )
+    return failures, not failures
 
 
 def _format_first_error(errors: list[dict[str, Any]] | list[ValidationErrorItem]) -> str:
@@ -275,7 +495,8 @@ async def validator(state: AgentState) -> dict[str, Any]:
     (
         current_game_state,
         modified_game_state,
-        _changes_log,
+        execution_plan,
+        changes_log,
         _backup_paths,
         retry_count,
     ) = extract_validation_inputs(state)
@@ -283,43 +504,47 @@ async def validator(state: AgentState) -> dict[str, Any]:
     logger.info("[Validator] 시작: files=%d, retry=%d", len(modified_game_state), retry_count)
 
     if not modified_game_state:
-        result = build_state_error(
-            "modified_game_state is missing or empty.",
-            retry_count=retry_count + 1,
+        result = build_state_error("modified_game_state is missing or empty.")
+    elif not execution_plan:
+        result = build_state_error("execution_plan is missing or empty.")
+    else:
+        current_entries = load_validation_entries(current_game_state)
+        modified_entries = load_validation_entries(modified_game_state)
+        detected_count, unchanged_count = summarize_modified_files(
+            current_entries, modified_entries
         )
-        return result.model_dump(mode="json", exclude_none=True)
+        logger.info(
+            "[Validator] 변경 감지 요약: detected=%d, unchanged=%d, total=%d",
+            detected_count,
+            unchanged_count,
+            len(modified_entries),
+        )
 
-    current_entries = load_validation_entries(current_game_state)
-    modified_entries = load_validation_entries(modified_game_state)
-    detected_count, unchanged_count = summarize_modified_files(current_entries, modified_entries)
-    logger.info(
-        "[Validator] 변경 감지 요약: detected=%d, unchanged=%d, total=%d",
-        detected_count,
-        unchanged_count,
-        len(modified_entries),
-    )
+        validation_targets = select_validation_targets(modified_entries)
+        validation_results = [
+            validate_single_file(file_name, payload, payload_errors)
+            for file_name, payload, payload_errors in validation_targets
+        ]
+        schema_success = calculate_schema_success(validation_results)
+        step_failures, step_success = await validate_execution_steps(execution_plan, changes_log)
+        final_validation_results = validation_results + step_failures
+        success = calculate_final_success(schema_success, step_success)
+        result = build_output(
+            validation_results=final_validation_results,
+            validation_summary=build_validation_summary(final_validation_results),
+            success=success,
+        )
 
-    validation_results = [
-        validate_single_file(file_name, payload, payload_errors)
-        for file_name, (payload, payload_errors) in modified_entries.items()
-    ]
-    success = all(item.success for item in validation_results)
-    validation_summary = build_validation_summary(validation_results)
-    next_retry_count = retry_count + 1 if not success else None
-    failed_count = sum(1 for item in validation_results if not item.success)
+    next_retry_count = calculate_retry_count(retry_count, result.success)
+    result = result.model_copy(update={"retry_count": next_retry_count})
+    failed_count = sum(1 for item in result.validation_results if not item.success)
 
     logger.info(
         "[Validator] 종료: success=%s, validated=%d, failed=%d, retry_count=%s",
-        success,
-        len(validation_results),
+        result.success,
+        len(result.validation_results),
         failed_count,
-        next_retry_count,
+        result.retry_count,
     )
 
-    result = build_output(
-        validation_results=validation_results,
-        validation_summary=validation_summary,
-        success=success,
-        retry_count=next_retry_count,
-    )
-    return result.model_dump(mode="json", exclude_none=True)
+    return finalize_output(result)

--- a/agent/prompts/validator_prompt.py
+++ b/agent/prompts/validator_prompt.py
@@ -1,4 +1,4 @@
-"""Validator prompts for summary and content consistency checks."""
+"""Validator prompts for summary, content consistency, and step validation checks."""
 
 from __future__ import annotations
 
@@ -47,6 +47,27 @@ _CONTENT_VALIDATION_SYSTEM = """\
 - reasoning은 짧고 구체적으로 작성합니다.
 """
 
+_STEP_VALIDATION_SYSTEM = """\
+당신은 planner step과 executor 실행 로그가 같은 작업을 의미하는지 판정하는 검증기입니다.
+
+입력으로 아래 두 항목이 제공됩니다.
+- planner_step: step_id, description, action_type, target_file
+- executor_log: step_id, tool_name, success, modified_files
+
+판정 목표:
+- 같은 step_id로 이미 대응된 planner step 1개와 executor log 1개가 의미상 맞는지 판단합니다.
+
+판단 규칙:
+- tool_name을 주 비교 근거로 사용합니다.
+- modified_files는 보조 근거로만 사용합니다.
+- query step은 modified_files가 비어 있어도 불일치로 단정하지 않습니다.
+- create/update/delete step도 modified_files만으로 성공/실패를 단정하지 않습니다.
+- tool_name이 planner의 action_type, target_file, description과 명백히 어긋나면 is_match=false입니다.
+- structured_skip_* 같은 tool_name은 planner step의 의도와 설명상 자연스러우면 일치로 볼 수 있습니다.
+- reasoning은 짧고 구체적으로 작성합니다.
+- 출력은 is_match와 reasoning만 제공합니다.
+"""
+
 
 def _json_dumps(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, indent=2)
@@ -89,8 +110,24 @@ def _build_content_validation_prompt(state: AgentState) -> list[BaseMessage]:
     ]
 
 
+def _build_step_validation_prompt(state: AgentState) -> list[BaseMessage]:
+    user_content = f"""## planner_step
+{_json_dumps(state.get("planner_step", {}))}
+
+## executor_log
+{_json_dumps(state.get("executor_log", {}))}
+"""
+
+    return [
+        SystemMessage(content=_STEP_VALIDATION_SYSTEM),
+        HumanMessage(content=user_content),
+    ]
+
+
 def build_prompt(state: AgentState) -> list[BaseMessage]:
     mode = str(state.get("_validator_prompt_mode", "summary")).lower()
     if mode == "content_validation":
         return _build_content_validation_prompt(state)
+    if mode == "step_validation":
+        return _build_step_validation_prompt(state)
     return _build_summary_prompt(state)

--- a/agent/schemas/actors.py
+++ b/agent/schemas/actors.py
@@ -22,19 +22,21 @@ class Actor(BaseModel):
 
     # --------------- 이미지
 
-    faceName: str = Field(description="읽어올 페이스 파일명") # pattern=r"^Actor\d+$" 여기
+    faceName: str = Field(description="읽어올 페이스 파일명")  # pattern=r"^Actor\d+$" 여기
     faceIndex: int = Field(
         description="인덱스 = 얼굴 이미지 결정, faceName보다 값 1 줄어야 함",
         ge=0,
         le=7,
     )
-    characterName: str = Field(description="읽어올 보행 캐릭터 파일명") # pattern=r"^Actor\d+$" 여기
+    characterName: str = Field(
+        description="읽어올 보행 캐릭터 파일명"
+    )  # pattern=r"^Actor\d+$" 여기
     characterIndex: int = Field(
         description="인덱스 = 보행 캐릭터 결정, characterName보다 값 1 줄어야 함",
         ge=0,
         le=7,
     )
-    battlerName: str = Field(description="전투 캐릭터 결정") # pattern=r"^Actor\d+_\d+$" 여기
+    battlerName: str = Field(description="전투 캐릭터 결정")  # pattern=r"^Actor\d+_\d+$" 여기
 
     # --------------- 초기 장비
 

--- a/agent/schemas/actors.py
+++ b/agent/schemas/actors.py
@@ -22,19 +22,19 @@ class Actor(BaseModel):
 
     # --------------- 이미지
 
-    faceName: str = Field(description="읽어올 페이스 파일명", pattern=r"^Actor\d+$")
+    faceName: str = Field(description="읽어올 페이스 파일명") # pattern=r"^Actor\d+$" 여기
     faceIndex: int = Field(
         description="인덱스 = 얼굴 이미지 결정, faceName보다 값 1 줄어야 함",
         ge=0,
         le=7,
     )
-    characterName: str = Field(description="읽어올 보행 캐릭터 파일명", pattern=r"^Actor\d+$")
+    characterName: str = Field(description="읽어올 보행 캐릭터 파일명") # pattern=r"^Actor\d+$" 여기
     characterIndex: int = Field(
         description="인덱스 = 보행 캐릭터 결정, characterName보다 값 1 줄어야 함",
         ge=0,
         le=7,
     )
-    battlerName: str = Field(description="전투 캐릭터 결정", pattern=r"^Actor\d+_\d+$")
+    battlerName: str = Field(description="전투 캐릭터 결정") # pattern=r"^Actor\d+_\d+$" 여기
 
     # --------------- 초기 장비
 

--- a/agent/schemas/animations.py
+++ b/agent/schemas/animations.py
@@ -73,10 +73,11 @@ class AnimationsFile(RootModel[Annotated[list[Animation | None], Field(min_lengt
         for idx, animation in enumerate(self.root):
             if animation is None:
                 continue
-
+            """
+            여기
             if "timings" in animation.model_fields_set and idx != 1:
                 raise ValueError(
                     f"Animations.json[{idx}].timings는 허용되지 않음. timings는 첫 번째 실제 애니메이션(인덱스 1)에서만 허용됨"
                 )
-
+            """
         return self

--- a/agent/schemas/effects.py
+++ b/agent/schemas/effects.py
@@ -36,7 +36,7 @@ EFFECT_RULES = {
     13: {
         "name": "TP 회복",
         "dataId": {"type": "range", "min": 0},
-        "value1": {"type": "range", "min": 0, "max": 30}, # 원래는 max 10
+        "value1": {"type": "range", "min": 0, "max": 30},  # 원래는 max 10
         "value2": {"type": "range", "min": 0},
     },
     21: {
@@ -78,7 +78,7 @@ EFFECT_RULES = {
     41: {
         "name": "특수 효과",
         "dataId": {"type": "exact", "value": 0},
-        "value1": {"type": "range", "min": 0, "max": 1}, # 원래는 "exact", "value": 1
+        "value1": {"type": "range", "min": 0, "max": 1},  # 원래는 "exact", "value": 1
         "value2": {"type": "exact", "value": 0},
     },
     42: {

--- a/agent/schemas/effects.py
+++ b/agent/schemas/effects.py
@@ -36,7 +36,7 @@ EFFECT_RULES = {
     13: {
         "name": "TP 회복",
         "dataId": {"type": "range", "min": 0},
-        "value1": {"type": "range", "min": 0, "max": 10},
+        "value1": {"type": "range", "min": 0, "max": 30}, # 원래는 max 10
         "value2": {"type": "range", "min": 0},
     },
     21: {
@@ -78,7 +78,7 @@ EFFECT_RULES = {
     41: {
         "name": "특수 효과",
         "dataId": {"type": "exact", "value": 0},
-        "value1": {"type": "exact", "value": 1},
+        "value1": {"type": "range", "min": 0, "max": 1}, # 원래는 "exact", "value": 1
         "value2": {"type": "exact", "value": 0},
     },
     42: {

--- a/agent/schemas/skills.py
+++ b/agent/schemas/skills.py
@@ -15,19 +15,19 @@ class Damage(BaseModel):
     critical: bool = Field(description="피해 > 치명타", default=True)
     variance: int = Field(description="피해 > 분산도", ge=0, le=100)
 
-    @field_validator("formula")
-    @classmethod
-    def validate_formula(cls, v: str) -> str:
-        if v == "0":
-            return v
+    # @field_validator("formula")
+    # @classmethod
+    # def validate_formula(cls, v: str) -> str:
+    #     if v == "0":
+    #         return v
 
-        token_pattern = r"(?:a|b)\.(?:atk|def|mhp|mat)|\d+(?:\.\d+)?|[+\-*/()]|\s+"
-        consumed = "".join(m.group(0) for m in re.finditer(token_pattern, v))
+    #     token_pattern = r"(?:a|b)\.(?:atk|def|mhp|mat)|\d+(?:\.\d+)?|[+\-*/()]|\s+"
+    #     consumed = "".join(m.group(0) for m in re.finditer(token_pattern, v))
 
-        if consumed != v:
-            raise ValueError("허용되지 않은 damage formula 형식입니다.")
+    #     if consumed != v:
+    #         raise ValueError("허용되지 않은 damage formula 형식입니다.")
 
-        return v
+    #     return v
 
 
 class Skill(BaseModel):
@@ -47,7 +47,7 @@ class Skill(BaseModel):
 
     # --------------- 발동
 
-    speed: int = Field(description="발동 > 속도 보정", ge=0, le=2000)
+    speed: int = Field(description="발동 > 속도 보정", le=2000) #ge=0, 
     successRate: int = Field(description="발동 > 성공률", ge=1, le=100)
     repeats: int = Field(description="발동 > 연속 횟수", ge=1, le=9)
     tpGain: int = Field(description="발동 > TP 획득", ge=0, le=100)

--- a/agent/schemas/skills.py
+++ b/agent/schemas/skills.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import re
 from typing import Annotated
 
-from pydantic import BaseModel, Field, RootModel, field_validator, model_validator
+from pydantic import BaseModel, Field, RootModel, model_validator  # field_validator,
 
 from .effects import Effect
 
@@ -47,7 +46,7 @@ class Skill(BaseModel):
 
     # --------------- 발동
 
-    speed: int = Field(description="발동 > 속도 보정", le=2000) #ge=0, 
+    speed: int = Field(description="발동 > 속도 보정", le=2000)  # ge=0,
     successRate: int = Field(description="발동 > 성공률", ge=1, le=100)
     repeats: int = Field(description="발동 > 연속 횟수", ge=1, le=9)
     tpGain: int = Field(description="발동 > TP 획득", ge=0, le=100)

--- a/agent/tests/test_validator.py
+++ b/agent/tests/test_validator.py
@@ -9,11 +9,13 @@ import types
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from agent.graph.nodes.validator import (
     FileValidationResult,
+    StepValidationLLMResult,
     ValidationErrorItem,
     ValidatorOutput,
     validator,
@@ -90,6 +92,21 @@ def build_default_changes_log(modified_files: list[str]) -> list[dict[str, Any]]
     ]
 
 
+def build_default_execution_plan(modified_files: list[str]) -> list[dict[str, Any]]:
+    return [
+        {
+            "step_id": index,
+            "description": f"{file_name} 파일 수동 validator 실행",
+            "action_type": "manual_validate",
+            "target_file": file_name,
+            "target_info": {},
+            "depends_on": [],
+            "condition": "",
+        }
+        for index, file_name in enumerate(modified_files, start=1)
+    ]
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
@@ -125,6 +142,13 @@ def parse_args() -> argparse.Namespace:
         default=None,
         metavar="PATH",
         help="Optional JSON file containing a changes_log array.",
+    )
+    parser.add_argument(
+        "--execution-plan",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Optional JSON file containing an execution_plan array.",
     )
     parser.add_argument(
         "--backup-path",
@@ -168,9 +192,17 @@ def build_state(args: argparse.Namespace) -> dict[str, Any]:
     else:
         changes_log = build_default_changes_log([path.name for path in modified_paths])
 
+    if args.execution_plan is not None:
+        execution_plan = load_json_file(args.execution_plan.resolve())
+        if not isinstance(execution_plan, list):
+            raise ValueError("--execution-plan must contain a JSON array")
+    else:
+        execution_plan = build_default_execution_plan([path.name for path in modified_paths])
+
     backup_paths = parse_backup_paths(args.backup_path)
 
     state = {
+        "execution_plan": execution_plan,
         "current_game_state": current_game_state,
         "modified_game_state": modified_game_state,
         "changes_log": changes_log,
@@ -313,6 +345,26 @@ def _base_validator_state() -> dict[str, Any]:
     modified_game_state["System.json"]["partyMembers"] = [1, 2]
 
     return {
+        "execution_plan": [
+            {
+                "step_id": 1,
+                "description": "Create actor Sofia with classId 1",
+                "action_type": "create",
+                "target_file": "Actors.json",
+                "target_info": {"actor_name": "Sofia", "class_id": 1},
+                "depends_on": [],
+                "condition": "",
+            },
+            {
+                "step_id": 2,
+                "description": "Add Sofia to partyMembers",
+                "action_type": "update",
+                "target_file": "System.json",
+                "target_info": {"actor_name": "Sofia"},
+                "depends_on": [1],
+                "condition": "",
+            },
+        ],
         "current_game_state": current_game_state,
         "modified_game_state": modified_game_state,
         "changes_log": [
@@ -321,14 +373,14 @@ def _base_validator_state() -> dict[str, Any]:
                 "target_file": "Actors.json",
                 "tool_name": "structured_actors_create",
                 "success": True,
-                "description": "Create actor Sofia with classId 1",
+                "description": "Create actor Sofia with classld 1",
             },
             {
                 "step_id": 2,
                 "target_file": "System.json",
                 "tool_name": "structured_system_update",
                 "success": True,
-                "description": "Add Sofia to partyMembers",
+                "description": "Add Sofia as a member of party",
             },
         ],
         "backup_paths": {},
@@ -432,6 +484,30 @@ def _write_snapshot_files(snapshot: dict[str, Any], directory: Path, prefix: str
     return written
 
 
+def _print_debug_block(title: str, value: Any) -> None:
+    print(f"\n=== {title} ===")
+    print(json.dumps(value, ensure_ascii=False, indent=2))
+
+
+@pytest.fixture(autouse=True)
+def mock_step_validation_llm():
+    async def _mock_invoke(_messages, structured_output=None):
+        if structured_output is None:
+            return "ok"
+        return structured_output.model_validate(
+            {
+                "is_match": True,
+                "reasoning": "planner step and executor log are aligned",
+            }
+        )
+
+    with patch(
+        "agent.graph.nodes.validator.invoke_llm",
+        new=AsyncMock(side_effect=_mock_invoke),
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_validator_validates_all_modified_game_state_files():
     state = _base_validator_state()
@@ -509,6 +585,24 @@ async def test_validator_schema_failure_increments_retry_count():
 
 
 @pytest.mark.asyncio
+async def test_validator_validates_only_files_present_in_modified_game_state():
+    state = _base_validator_state()
+    state["current_game_state"]["Unknown.json"] = {"foo": "bar"}
+    state["modified_game_state"] = {
+        "Actors.json": deepcopy(state["modified_game_state"]["Actors.json"]),
+    }
+
+    result = await validator(state)
+    contract = ValidatorOutput.model_validate(result)
+
+    assert contract.success is True
+    assert contract.retry_count is None
+    assert [item.target for item in contract.validation_results] == ["Actors.json"]
+    assert "Unknown.json" not in [item.target for item in contract.validation_results]
+    assert result["validation_summary"] == "총 1개 파일이 모두 스키마 검증을 통과했습니다."
+
+
+@pytest.mark.asyncio
 async def test_validator_unsupported_schema_returns_standard_shape():
     state = _base_validator_state()
     state["modified_game_state"]["Unknown.json"] = {"foo": "bar"}
@@ -525,6 +619,133 @@ async def test_validator_unsupported_schema_returns_standard_shape():
     assert result["retry_count"] == 1
     assert "validation_result" not in result
     assert result["validation_summary"] == "총 4개 파일 중 1개 파일 검증에 실패했습니다."
+
+
+@pytest.mark.asyncio
+async def test_validator_empty_modified_game_state_increments_retry_count():
+    state = _base_validator_state()
+    state["modified_game_state"] = {}
+    state["retry_count"] = 2
+
+    result = await validator(state)
+    contract = ValidatorOutput.model_validate(result)
+
+    assert contract.success is False
+    assert contract.retry_count == 3
+    assert contract.validation_summary == "modified_game_state is missing or empty."
+    assert len(contract.validation_results) == 1
+    assert contract.validation_results[0].target == "state"
+    assert (
+        contract.validation_results[0].errors[0].msg == "modified_game_state is missing or empty."
+    )
+
+
+@pytest.mark.asyncio
+async def test_validator_missing_execution_plan_returns_state_error():
+    state = _base_validator_state()
+    state.pop("execution_plan")
+
+    result = await validator(state)
+    contract = ValidatorOutput.model_validate(result)
+
+    assert contract.success is False
+    assert contract.retry_count == 1
+    assert contract.validation_summary == "execution_plan is missing or empty."
+    assert len(contract.validation_results) == 1
+    assert contract.validation_results[0].target == "state"
+    assert contract.validation_results[0].errors[0].msg == "execution_plan is missing or empty."
+
+
+@pytest.mark.asyncio
+async def test_validator_step_validation_missing_executor_log_adds_failure():
+    state = _base_validator_state()
+    state["changes_log"] = [state["changes_log"][0]]
+
+    result = await validator(state)
+
+    assert result["success"] is False
+    assert result["retry_count"] == 1
+    step_result = next(item for item in result["validation_results"] if item["target"] == "step:2")
+    assert step_result["success"] is False
+    assert "changes_log에 없습니다" in step_result["errors"][0]["msg"]
+
+
+@pytest.mark.asyncio
+async def test_validator_step_validation_executor_failure_adds_failure():
+    state = _base_validator_state()
+    state["changes_log"][1] = {
+        "step_id": 2,
+        "tool_name": "structured_system_update",
+        "success": False,
+        "error": "executor failed",
+    }
+
+    result = await validator(state)
+
+    assert result["success"] is False
+    assert result["retry_count"] == 1
+    step_result = next(item for item in result["validation_results"] if item["target"] == "step:2")
+    assert "executor failed" in step_result["errors"][0]["msg"]
+
+
+@pytest.mark.asyncio
+async def test_validator_step_validation_llm_mismatch_adds_failure():
+    state = _base_validator_state()
+
+    with patch("agent.graph.nodes.validator.invoke_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.return_value = StepValidationLLMResult(
+            is_match=False,
+            reasoning="planner step은 System.json update인데 executor tool_name이 다른 작업으로 판정됨",
+        )
+        result = await validator(state)
+
+    assert result["success"] is False
+    assert result["retry_count"] == 1
+    step_result = next(item for item in result["validation_results"] if item["target"] == "step:1")
+    assert "planner step은" in step_result["errors"][0]["msg"]
+
+
+@pytest.mark.asyncio
+async def test_validator_query_step_allows_empty_modified_files_when_llm_matches():
+    state = _base_validator_state()
+    state["execution_plan"] = [
+        {
+            "step_id": 1,
+            "description": "Actors.json에서 Sofia 존재 여부 조회",
+            "action_type": "query",
+            "target_file": "Actors.json",
+            "target_info": {"actor_name": "Sofia"},
+            "depends_on": [],
+            "condition": "",
+        }
+    ]
+    state["changes_log"] = [
+        {
+            "step_id": 1,
+            "tool_name": "structured_actors_query",
+            "success": True,
+            "modified_files": [],
+        }
+    ]
+
+    result = await validator(state)
+
+    assert result["success"] is True
+    assert "retry_count" not in result
+    assert all(item["target"] != "step:1" for item in result["validation_results"])
+
+
+@pytest.mark.asyncio
+async def test_validator_debug_print_execution_plan_changes_log_and_result():
+    state = _base_validator_state()
+
+    result = await validator(state)
+
+    _print_debug_block("execution_plan", state["execution_plan"])
+    _print_debug_block("changes_log", state["changes_log"])
+    _print_debug_block("validator_result", result)
+
+    assert result["success"] is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
---
## 1. Validator 출력/재시도 흐름 정리
  Validator의 최종 반환 경로를 `ValidatorOutput` 기준 단일 흐름으로 정리하고, 실패 처리 정책을 일관되게 맞췄습니다.

 **배경:**
  - 최종 `model_dump(...)` 지점이 분산되어 있었음
  - 형식 검증 대상이 `modified_game_state`라는 기준이 구조적으로 명확하지 않았음
  - `retry_count` 증가 정책이 분기별로 흩어져 있었음

**변경:**
  - 최종 직렬화를 `finalize_output(...)` 한 지점으로 통합
  - 형식 검증 대상을 `modified_game_state` 항목으로 명시
  - `success=False`인 모든 경우 최종 `success` 기준으로 `retry_count` 증가

##2. Step validation 최소 기능 추가
  기존 스키마 검증 위에 planner의 `execution_plan`과 executor의 `changes_log`를 `step_id` 기준으로 비교하는 step validation을 추가했습니다.

**변경:**
  - `extract_validation_inputs(...)`가 `execution_plan`도 읽고 정규화
  - planner step과 executor log를 `step_id` 기준 1:1 대응
  - 대응 log 누락, executor 실패, planner/executor 의미 불일치를 step validation 실패로 처리
  - step validation 실패는 `target="step:{step_id}"` 형태의 synthetic `FileValidationResult`로 `validation_results`에 추가
  - 최종 `success`는 `schema_success and step_success` 기준으로 계산
  - step validation 실패도 `retry_count` 증가 대상에 포함

##3. Step validation용 LLM / prompt 추가
  planner step과 executor log의 의미 일치를 LLM structured output으로 판정하도록 추가했습니다.

**변경:**
  - `judge_step_match_with_llm(...)` helper 추가
  - `StepValidationLLMResult` structured output 모델 추가
  - `validator_prompt.py`에 `step_validation` 모드 추가
  - `tool_name`을 주 비교 근거로, `modified_files`를 보조 근거로 사용
  - query step은 `modified_files`가 비어 있어도 mismatch로 단정하지 않도록 처리

##4. Validator 로깅 및 테스트 보강
  새로 추가된 step validation 경로도 로그와 테스트에서 추적 가능하게 정리했습니다.

**변경:**
  - step 검증 시작/대상/보류/실패/통과/종료 로그 추가
  - `test_validator.py`에 step validation 성공/누락/executor 실패/LLM mismatch/query 케이스 추가
  - validator 단독 실행 드라이버에 `--execution-plan` 입력 추가
  - `execution_plan`, `changes_log`, `validator_result`를 출력하는 debug test 추가

##5. Strict schema validation 복구
  validator가 schema 제약을 base-game에 적용하도록 수정했습니다.
  *단, 스키마 제약이 완화된 것이기에 추후 다시 손봐야 합니다.

  Test Plan
  - [ ] `uv run pytest agent\tests\test_validator.py -q`
  - [ ] schema validation 성공/실패 케이스 확인
  - [ ] `modified_game_state` 기준 형식 검증 확인
  - [ ] `execution_plan` 누락 시 state-level 실패 확인
  - [ ] step log 누락 / executor 실패 / LLM mismatch 시 synthetic `step:{step_id}` 실패 결과 확인
  - [ ] query step에서 `modified_files=[]`여도 통과 가능한지 확인
  - [ ] `uv run pytest agent\tests\test_validator.py -s -k debug_print_execution_plan_changes_log_and_result` 로 debug 출력 확인 가능