### PR TITLE
refactor: planner 프롬프트 개선 - 불필요한 계획 수립 방지

### DIFF
--- a/agent/graph/nodes/planner.py
+++ b/agent/graph/nodes/planner.py
@@ -46,8 +46,10 @@ class _ExecutionStep(BaseModel):
 
 
 class _PlannerOutput(BaseModel):
+    reasoning: str = Field(
+        description="계획 수립 전 사고 과정: 사용자 요청에서 실제로 필요한 작업이 무엇인지, 불필요한 엔티티는 무엇인지 먼저 정리"
+    )
     execution_plan: list[_ExecutionStep] = Field(description="순서 있는 실행 단계 목록")
-    reasoning: str = Field(description="계획 수립 근거 (로깅용)")
 
 
 async def planner(state: AgentState) -> dict:

--- a/agent/prompts/planner_prompt.py
+++ b/agent/prompts/planner_prompt.py
@@ -50,6 +50,13 @@ _SYSTEM_PROMPT = """\
 
 ## 계획 수립 지침
 
+### 핵심 원칙: 요청 범위 한정
+- **사용자가 명시적으로 언급했거나, 요청 달성에 직접적으로 필요한 대상만** 계획에 포함할 것
+- 파일 구조의 참조 관계를 따라 연쇄적으로 관련 엔티티를 조회/생성하지 말 것
+- 사용자가 언급하지 않은 엔티티(직업, 무기, 방어구 등)는 계획에 포함하지 말 것
+- 판단 기준: "이 step이 없으면 사용자의 요청을 완료할 수 없는가?" → 아니라면 제외
+
+### 작업 규칙
 1. 각 step은 단일 원자 작업으로 쪼갤 것
 2. 존재 여부가 불확실한 대상은 반드시 query step을 먼저 배치할 것
 3. condition 필드로 조건부 실행을 표현할 것
@@ -63,13 +70,19 @@ _SYSTEM_PROMPT = """\
    - Actors.json에서 query만 써야 할 때: ID 조회는 actor_id, 이름 존재 확인은 actor_name/name, 전체 목록은 target_info에 list_actors=true, 부분 검색은 searchTerm만(이름 키 없이)
    - Actors.json 수정: 생성 직후 같은 흐름에서 수정하면 depends_on으로 이어 주고, target_info에 actor_id를 반복하지 않아도 됨(Executor가 선행 step의 actor_id를 채움). 이름 변경은 actor_id+new_name 또는 actor_name+new_name, 일반 필드는 updates+actor_id
 
+### 응답 순서 (Chain-of-Thought)
+반드시 아래 순서로 사고하고 출력할 것:
+1. **reasoning을 먼저 작성**: 사용자 요청을 분석하여 "이 요청을 완료하려면 실제로 필요한 작업이 무엇인가?"를 정리. 요청과 무관한 엔티티가 있다면 왜 제외하는지 명시.
+2. **execution_plan을 작성**: reasoning에서 필요하다고 판단한 작업만 계획에 포함.
+
 ---
 
-## 출력 예시
+## 올바른 출력 예시
 
 사용자 요청: "주인공에게 파이어볼 스킬을 추가해줘"
 
 {
+  "reasoning": "사용자는 '주인공'에게 '파이어볼 스킬'을 추가하길 원한다. 필요한 작업: (1) 파이어볼 스킬 존재 확인 및 생성, (2) 주인공에게 스킬 부여. 주인공의 직업(Classes)이나 장비(Weapons/Armors)는 요청에 언급되지 않았으므로 계획에 포함하지 않는다.",
   "execution_plan": [
     {
       "step_id": 1,
@@ -98,9 +111,31 @@ _SYSTEM_PROMPT = """\
       "depends_on": [1, 2],
       "condition": ""
     }
-  ],
-  "reasoning": "스킬을 먼저 생성한 뒤, 직업 전체가 아닌 주인공 개인에게만 부여하므로 Actors.json traits[]에 직접 등록"
+  ]
 }
+
+---
+
+## 잘못된 출력 예시 (이렇게 하지 마세요)
+
+사용자 요청: "리드에게 파이어볼 스킬을 추가해줘"
+
+아래는 **잘못된 계획**입니다. 사용자는 스킬 추가만 요청했는데, 요청에 없는 '검사' 클래스까지 조회/생성하고 있습니다.
+
+{
+  "execution_plan": [
+    {"step_id": 1, "action_type": "query", "target_file": "Skills.json", "description": "파이어볼 스킬 조회"},
+    {"step_id": 2, "action_type": "create", "target_file": "Skills.json", "description": "파이어볼 스킬 생성"},
+    {"step_id": 3, "action_type": "query", "target_file": "Classes.json", "description": "검사 클래스 조회 ← ❌ 불필요"},
+    {"step_id": 4, "action_type": "create", "target_file": "Classes.json", "description": "검사 클래스 생성 ← ❌ 불필요"},
+    {"step_id": 5, "action_type": "query", "target_file": "Actors.json", "description": "리드 캐릭터 조회"},
+    {"step_id": 6, "action_type": "create", "target_file": "Actors.json", "description": "리드 캐릭터 생성"},
+    {"step_id": 7, "action_type": "update", "target_file": "Actors.json", "description": "리드에게 파이어볼 부여"}
+  ]
+}
+
+❌ 문제점: 사용자가 '클래스'를 언급하지 않았는데 Classes.json을 조회/생성하는 step 3, 4가 포함됨.
+✅ 올바른 계획: Skills.json 조회/생성 → Actors.json 조회/생성 → Actors.json 업데이트 (총 5단계)
 """
 
 


### PR DESCRIPTION
## Summary
  - Planner가 사용자 요청과 무관한 엔티티(예: 스킬 추가 요청 시 Classes.json 조회/생성)까지 계획에 포함하는 과잉 계획 문제 수정
  - 프롬프트에 요청 범위 한정 지침, 반례(Negative example), Chain-of-Thought 순서를 추가하여 LLM이 필요한 작업만 계획하도록 개선

  **원인 분석:**
  1. 프롬프트에 "어떤 대상까지 계획에 포함할지"에 대한 범위 기준이 없었음
  2. LLM이 파일 구조의 참조 관계(Actor→classId→Classes)를 따라 연쇄적으로 관련 엔티티까지 조회/생성하는 과잉 계획을 수립
  3. "하지 말아야 할 것"에 대한 예시가 없어 LLM이 보수적으로 모든 참조를 보장하려 함

  ## Changes
  - `agent/prompts/planner_prompt.py`: 범위 한정 원칙, 잘못된 출력 예시, CoT 응답 순서 지침 추가
  - `agent/graph/nodes/planner.py`: `_PlannerOutput` 스키마에서 `reasoning` 필드를 `execution_plan` 앞으로 이동

  ## Test plan
  - [x] "리드에게 파이어볼 스킬을 추가해줘" 요청 시 Classes.json 관련 step이 생성되지 않는지 확인
  - [ ] 다양한 요청(조회, 생성, 수정, 삭제)에서 불필요한 step 없이 계획이 수립되는지 확인