### PR TITLE
fix: docker 환경에서 프론트 띄울 때 발생하는 404 잡기

### DIFF
--- a/app/frontend/vite.config.js
+++ b/app/frontend/vite.config.js
@@ -57,6 +57,11 @@ export default defineConfig({
         target: 'http://localhost:8000',
         changeOrigin: true,
       },
+      // 새로 추가 - docker로 프론트/백엔드 같이 띄울 때 필요한 설정
+      '/game': {
+        target: 'http://backend:8000',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
도커로 프론트&백엔드 모두 띄울 때 게임 화면에서 404 error가 발생합니다
-> 프론트 vite.config.js에서 수정하는 것으로 해결