### PR TITLE
feat: 맵뷰어 이벤트 분류 개선 및 프로젝트 시간 한국시간 수정

### DIFF
--- a/app/frontend/src/components/game/MapViewer.jsx
+++ b/app/frontend/src/components/game/MapViewer.jsx
@@ -257,12 +257,21 @@ function Tag({ color, children }) {
   )
 }
 
-// ── 이벤트 종류 → 색상 ────────────────────────────────────────
+// ── 이벤트 종류 판별 (커맨드 코드 기반) ──────────────────────
+function getEventType(event) {
+  for (const page of (event.pages ?? [])) {
+    for (const cmd of (page.list ?? [])) {
+      if (cmd.code === 201) return 'warp'
+      if (cmd.code === 301) return 'battle'
+      if (cmd.code === 101 || cmd.code === 102 || cmd.code === 302) return 'npc'
+    }
+  }
+  return 'other'
+}
+
+const EVENT_COLOR = { warp: '#5b8dee', npc: '#4caf82', battle: '#e05252', other: '#f0a500' }
 function getEventColor(event) {
-  const name = event.name ?? ''
-  if (/위치.?이동|워프|warp/i.test(name)) return '#5b8dee'
-  if (/npc|상인|마을|촌장|노인|여자|남자|병사/i.test(name)) return '#4caf82'
-  return '#f0a500'
+  return EVENT_COLOR[getEventType(event)]
 }
 
 // ── 이미지 로드 헬퍼 ──────────────────────────────────────────
@@ -503,7 +512,7 @@ export default function MapViewer({ gameId, refreshKey }) {
                   >
                     {cellSize >= 16 && (
                       <span style={{ fontSize: Math.max(8, cellSize * 0.4), lineHeight: 1, color }}>
-                        {/위치.?이동|워프/i.test(ev.name ?? '') ? '⬡' : '●'}
+                        {getEventType(ev) === 'warp' ? '⬡' : '●'}
                       </span>
                     )}
                   </div>
@@ -571,8 +580,9 @@ export default function MapViewer({ gameId, refreshKey }) {
         className="flex items-center gap-4 px-3 py-1.5 flex-shrink-0 text-xs"
         style={{ borderTop: '1px solid var(--border)', background: 'var(--bg-secondary)', color: 'var(--text-secondary)' }}
       >
-        <Legend color="#5b8dee" label="워프" />
-        <Legend color="#4caf82" label="NPC" />
+        <Legend color="#5b8dee" label="워프(201)" />
+        <Legend color="#4caf82" label="NPC(101·102·302)" />
+        <Legend color="#e05252" label="전투(301)" />
         <Legend color="#f0a500" label="기타 이벤트" />
         <span style={{ marginLeft: 'auto' }}>클릭 시 상세 보기</span>
       </div>

--- a/app/frontend/src/pages/Dashboard.jsx
+++ b/app/frontend/src/pages/Dashboard.jsx
@@ -6,7 +6,8 @@ import Header from '../components/layout/Header'
 import Modal from '../components/common/Modal'
 
 function relativeTime(dateStr) {
-  const diff = Date.now() - new Date(dateStr).getTime()
+  const utcStr = dateStr && !dateStr.endsWith('Z') && !dateStr.includes('+') ? dateStr + 'Z' : dateStr
+  const diff = Date.now() - new Date(utcStr).getTime()
   const minutes = Math.floor(diff / 60000)
   if (minutes < 1) return '방금 전'
   if (minutes < 60) return `${minutes}분 전`


### PR DESCRIPTION
## Summary

- 맵뷰어 이벤트 분류를 이름 regex 기반 → 커맨드 코드 기반으로 변경
  - RPG Maker MZ 이벤트 이름이 `EV001` 형태라 regex가 전혀 매칭되지 않던 문제 수정
  - 워프(201), 전투(301), NPC(101·102·302) 커맨드 코드로 정확히 분류
  - 전투 이벤트 빨간색 표시 추가
  - 범례에 커맨드 코드 표기 추가
- 프로젝트 목록 수정 시간 한국 시간 기준으로 올바르게 표시
  - 백엔드가 UTC 타임스탬프를 Z 없이 반환 시 JS가 로컬 시간으로 파싱해 9시간 오차 발생하던 문제 수정

## Test plan

- [x] 맵뷰어에서 워프 이벤트가 파란색 육각형으로 표시되는지 확인
- [x] NPC 이벤트가 초록색 동그라미로 표시되는지 확인
- [x] 전투 이벤트가 빨간색으로 표시되는지 확인
- [x] 프로젝트 목록에서 수정 시간이 올바르게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)