### PR TITLE
fix: 로그 출력 양식 통일, .env.example 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,15 +29,24 @@ MAX_PROJECTS_PER_USER=3
 # 4단계 Executor가 stdio MCP 서버(Node)를 서브프로세스로 실행할 때 사용.
 # - 로컬(맥): MCP_NODE_SERVER_PATH는 호스트 절대 경로(예: /Users/you/.../dist/index.js)
 # - Docker(EC2): 이미지에 포함된 경로(기본: /app/mcp-server/dist/index.js)
-MCP_ENABLED=false
+MCP_ENABLED=true
+
+# 로컬로 실행할 경우 아래 주석 해제
+# MCP_NODE_SERVER_PATH=C:\Users\yebin\Desktop\-rpgmaker-mz-mcp\dist\index.js
+# MCP_CWD=C:\Users\yebin\Desktop\-rpgmaker-mz-mcp
+
+# 도커로 실행할 경우 아래 주석 해제
 MCP_NODE_SERVER_PATH=/app/mcp-server/dist/index.js
+MCP_CWD=/app/mcp-server
+
 # (선택) 기본은 targetDir. MCP 서버가 요구하는 경로 인자 키로 변경.
 MCP_PATH_ARG_NAME=targetDir
+
 # (선택) 초 단위 타임아웃
-MCP_TIMEOUT=30
+# MCP_TIMEOUT=30
 
 # ── AWS S3 (EC2 IAM 역할 사용 시 ACCESS_KEY 불필요) ───────────
-AWS_REGION=ap-northeast-2
+AWS_REGION=us-east-1
 S3_BUCKET_NAME=upstage-sesac-31-reverse-project-s3
 S3_PREFIX=games                        # 버킷 내 prefix (games/game_001/data/...)
 
@@ -50,20 +59,23 @@ LLM_TEMPERATURE=0.0
 LLM_PARALLEL_TOOL_CALLS=false          # Solar API 호환성을 위해 false 권장
 
 # ── Agent 동작 ────────────────────────────────────────────────
-AGENT_TIMEOUT=30                       # Agent 최대 대기 시간 (초)
+AGENT_TIMEOUT=60                       # Agent 최대 대기 시간 (초)
 MAX_RETRIES=3
 
-# ── LangSmith ──────────────────────────────────────────
+# ── LangSmith ─────────────────────────────────────────────────
 LANGSMITH_API_KEY=                     # 비워두면 트레이싱 비활성화
 LANGSMITH_PROJECT=Re-Verse
 LANGSMITH_TRACING=false
 
-# ── Logging ───────────────────────────────────────────
+#── admin_page ─────────────────────────────────────────────────
+ADMIN_EMAIL=admin@gmail.com
+
+# ── Logging ───────────────────────────────────────────────────
 LOG_LEVEL=DEBUG                        # DEBUG | INFO | WARNING | ERROR (미설정 시 DEBUG/ENVIRONMENT로 자동 결정)
 LOG_DIR=./logs                         # 로그 파일 저장 경로
 LOG_LEVEL_SQLALCHEMY=WARNING           # SQLAlchemy 로거 레벨 오버라이드
 LOG_LEVEL_HTTPX=WARNING                # HTTPX 로거 레벨 오버라이드
 
-# Frontend (VITE_ prefix 필수)
+#── Frontend (VITE prefix 필수) ────────────────────────────────
 VITE_API_URL=/api
 VITE_USE_MOCK=False

--- a/agent/graph/nodes/definition.py
+++ b/agent/graph/nodes/definition.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import time
 from typing import cast
 
 from agent.core.llm_client import invoke_llm
@@ -157,6 +158,9 @@ async def definition(state: AgentState) -> dict:
     """사용자 입력에서 핵심 파라미터 추출(1단계) 후 최종 명세 생성(5단계) 수행."""
     game_id = state.get("game_id", "game_001")
     user_input = state.get("user_input", "")
+    _t0 = time.perf_counter()
+
+    logger.info("─── 🧩 Definition START ───────────────────────────────")
 
     logger.info("=" * 60)
     logger.info("[Definition] 노드 시작 - game_id: %s, user_input: %s", game_id, user_input)
@@ -450,10 +454,19 @@ async def definition(state: AgentState) -> dict:
 
     logger.info("[Definition] 노드 완료 - 생성된 modification 수: %d", len(strictly_formatted_mods))
     # 최종 결과 반환
-    return {
+    result = {
         "target_files": final_response.target_files,
         "modifications": strictly_formatted_mods,
         "extracted_ids": final_extracted_ids,
         "params_sufficient": final_response.params_sufficient,
         # "final_response": final_response.message_for_user,
     }
+    logger.info(
+        "─── ✅ Definition END (elapsed=%.2fs, targets=%d, mods=%d, ids=%d, params_ok=%s) ──",
+        time.perf_counter() - _t0,
+        len(final_response.target_files),
+        len(strictly_formatted_mods),
+        len(final_extracted_ids),
+        final_response.params_sufficient,
+    )
+    return result

--- a/agent/graph/nodes/executor.py
+++ b/agent/graph/nodes/executor.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import shutil
+import time
 import uuid
 from collections import defaultdict
 from datetime import datetime
@@ -1262,7 +1263,7 @@ async def _execute_one_structured_step(
         )
         logger.error("[Executor] 미지원 스텝: %s", err)
         step_results[sid] = {"success": False, "error": err, "step_id": sid}
-        return {
+        result = {
             "step_id": sid,
             "tool_name": f"structured_{target_file}_{action}_UNSUPPORTED",
             "success": False,
@@ -1271,10 +1272,11 @@ async def _execute_one_structured_step(
             "structured": True,
             "timestamp": ts,
         }
+        return result
     except Exception as e:
         logger.exception("[Executor] 구조화 스텝 실행 실패 step_id=%s", sid)
         step_results[sid] = {"success": False, "error": str(e), "step_id": sid}
-        return {
+        result = {
             "step_id": sid,
             "tool_name": "structured_error",
             "success": False,
@@ -1282,6 +1284,7 @@ async def _execute_one_structured_step(
             "structured": True,
             "timestamp": ts,
         }
+        return result
 
 
 async def _executor_structured(
@@ -1396,13 +1399,14 @@ async def _executor_structured(
     )
 
     modified_file_paths = _collect_modified_file_paths_from_changes_log(data_path, changes_log)
-    return {
+    result = {
         "modified_game_state": modified_game_state,
         "current_game_state": current_game_state,
         "changes_log": changes_log,
         "tool_results": changes_log,  # progress.md 호환성을 위해 changes_log와 동일하게 설정
         "modified_file_paths": modified_file_paths,
     }
+    return result
 
 
 # ────────────────────────────────────────────────────────────
@@ -1434,6 +1438,32 @@ async def executor(state: AgentState) -> dict:
     game_id = state.get("game_id", "game_001")
     retry_count = state.get("retry_count", 0)
     user_input = state.get("user_input", "")
+    _t0 = time.perf_counter()
+
+    logger.info("─── 🛠️ Executor START ───────────────────────────────")
+
+    def _finish(result: dict[str, Any], *, mode: str, icon: str | None = None) -> dict[str, Any]:
+        changes_log = result.get("changes_log", [])
+        if not isinstance(changes_log, list):
+            changes_log = []
+
+        modified_file_paths = result.get("modified_file_paths", [])
+        if not isinstance(modified_file_paths, list):
+            modified_file_paths = []
+
+        failed = sum(1 for entry in changes_log if not entry.get("success"))
+        ok = sum(1 for entry in changes_log if entry.get("success"))
+        logger.info(
+            "─── %s Executor END (elapsed=%.2fs, mode=%s, steps=%d, ok=%d, failed=%d, files=%d) ──",
+            icon or ("⚠️" if failed else "✅"),
+            time.perf_counter() - _t0,
+            mode,
+            len(changes_log),
+            ok,
+            failed,
+            len(modified_file_paths),
+        )
+        return result
 
     logger.info("[Executor MVP] 시작: game_id=%s, retry=%d", game_id, retry_count)
 
@@ -1443,7 +1473,7 @@ async def executor(state: AgentState) -> dict:
     # ── Step 1: 입력 검증 ─────────────────────────────────────
     if retry_count >= 2:
         logger.warning("최대 재시도 초과")
-        return {
+        result = {
             "changes_log": [
                 {
                     "success": False,
@@ -1454,10 +1484,11 @@ async def executor(state: AgentState) -> dict:
             "tool_results": [],
             "modified_file_paths": [],
         }
+        return _finish(result, mode="guard", icon="\u26a0\ufe0f")
 
     if not execution_plan:
         logger.warning("execution_plan이 비어있음")
-        return {
+        result = {
             "changes_log": [
                 {
                     "error": "execution_plan이 비어있습니다.",
@@ -1467,6 +1498,7 @@ async def executor(state: AgentState) -> dict:
             "tool_results": [],
             "modified_file_paths": [],
         }
+        return _finish(result, mode="guard", icon="\u26a0\ufe0f")
 
     try:
         ep_json = json.dumps(execution_plan, ensure_ascii=False, default=str)
@@ -1522,7 +1554,7 @@ async def executor(state: AgentState) -> dict:
                 if "UNSUPPORTED" in str(failed.get("tool_name", "")):
                     logger.error("[Executor] CRITICAL 실패: %s", failed.get("stderr"))
 
-        return result
+        return _finish(result, mode="structured")
 
     logger.info("[Executor] 비구조화(번역) 경로: %d개 항목", len(execution_plan))
 
@@ -1532,7 +1564,7 @@ async def executor(state: AgentState) -> dict:
         logger.info("[Executor MVP] 번역 완료: %d개 툴", len(translated_plan.tools))
     except Exception as e:
         logger.error("[Executor MVP] 번역 실패: %s", e)
-        return {
+        result = {
             "changes_log": [
                 {
                     "success": False,
@@ -1543,6 +1575,7 @@ async def executor(state: AgentState) -> dict:
             "tool_results": [],
             "modified_file_paths": [],
         }
+        return _finish(result, mode="legacy", icon="\u274c")
 
     # ── Step 4: 대상 파일 수집 및 백업 ────────────────────────
     target_files = set()
@@ -1662,13 +1695,14 @@ async def executor(state: AgentState) -> dict:
     )
 
     modified_file_paths = _collect_modified_file_paths_from_changes_log(data_path, changes_log)
-    return {
+    result = {
         "modified_game_state": modified_game_state,
         "current_game_state": current_game_state,
         "changes_log": changes_log,
         "tool_results": changes_log,  # progress.md 호환성을 위해 changes_log와 동일하게 설정
         "modified_file_paths": modified_file_paths,
     }
+    return _finish(result, mode="legacy")
 
 
 # ────────────────────────────────────────────────────────────

--- a/agent/graph/nodes/planner.py
+++ b/agent/graph/nodes/planner.py
@@ -16,6 +16,7 @@
 
 import json
 import logging
+import time
 from typing import Literal, cast
 
 from pydantic import BaseModel, Field
@@ -61,7 +62,8 @@ async def planner(state: AgentState) -> dict:
     Returns:
         execution_plan 을 담은 dict.
     """
-    logger.info("=" * 60)
+    _t0 = time.perf_counter()
+    logger.info("─── 🗺️ Planner START ────────────────────────────────")
     logger.info("[Planner] 노드 진입")
     logger.info(
         "[Planner] 입력 state | intent=%s | target_files=%s",
@@ -121,6 +123,11 @@ async def planner(state: AgentState) -> dict:
         execution_plan = []
 
     logger.info("[Planner] 노드 종료 | 반환 step 수=%d", len(execution_plan))
-    logger.info("=" * 60)
 
+    logger.info(
+        "─── %s Planner END (elapsed=%.2fs, steps=%d) ─────────────────",
+        "✅" if execution_plan else "⚠️",
+        time.perf_counter() - _t0,
+        len(execution_plan),
+    )
     return {"execution_plan": execution_plan}

--- a/agent/graph/nodes/validator.py
+++ b/agent/graph/nodes/validator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import time
 from pathlib import Path
 from typing import Any
 
@@ -501,6 +502,9 @@ async def validator(state: AgentState) -> dict[str, Any]:
         retry_count,
     ) = extract_validation_inputs(state)
 
+    _t0 = time.perf_counter()
+    logger.info("─── 🔎 Validator START ──────────────────────────────")
+
     logger.info("[Validator] 시작: files=%d, retry=%d", len(modified_game_state), retry_count)
 
     if not modified_game_state:
@@ -547,4 +551,12 @@ async def validator(state: AgentState) -> dict[str, Any]:
         result.retry_count,
     )
 
+    logger.info(
+        "─── %s Validator END (elapsed=%.2fs, validated=%d, failed=%d, retry_count=%s) ──",
+        "✅" if result.success else "⚠️",
+        time.perf_counter() - _t0,
+        len(result.validation_results),
+        failed_count,
+        result.retry_count,
+    )
     return finalize_output(result)


### PR DESCRIPTION
agent 노드에서 각 단계별 시작/종료 시점 출력되는 양식을 통일했습니다(아래처럼 예쁘게)

 ─── 🔀 Router START ────────────────────────────────
 ─── ✅ Router END → 게임_요소_조회 (next: definition) ──────────────

 ─── 🧩 Definition START ──────────────────────────────
 ─── ✅ Definition END (elapsed=4.66s, targets=1, mods=1, ids=1, params_ok=True) ──

 ─── 🗺️ Planner START ────────────────────────────────
 ─── ✅ Planner END (elapsed=1.11s, steps=1) ─────────────────

 ─── 🛠️ Executor START ───────────────────────────────
 ─── ✅ Executor END (elapsed=1.12s, mode=structured, steps=1, ok=1, failed=0, files=0) ──

 ─── 🔎 Validator START ──────────────────────────────
 ─── ✅ Validator END (elapsed=1.19s, validated=1, failed=0, retry_count=None) ──

 ─── ✍️  Synthesizer START ──────────────────────────────
 ─── ✅ Synthesizer END (elapsed=1.69s, len=196) ────────────

그리고 .env.example의 내용을 최신화된 내용으로 맞췄습니다.