### PR TITLE
Feat/jc lee/workflow

### DIFF
--- a/agent/graph/nodes/executor.py
+++ b/agent/graph/nodes/executor.py
@@ -112,6 +112,218 @@ MCP_TOOL_MAP: dict[tuple[str, str], dict[str, Any]] = {
 }
 
 
+def _coerce_list_from_mcp_search_payload(data: Any) -> list[Any]:
+    """MCP 검색 응답 JSON 형태가 제각각일 때 리스트 후보를 꺼낸다."""
+    if data is None:
+        return []
+    if isinstance(data, list):
+        return data
+    if not isinstance(data, dict):
+        return []
+    for key in ("items", "results", "matches", "data", "actors", "skills", "enemies"):
+        v = data.get(key)
+        if isinstance(v, list):
+            return v
+    for key in ("item", "actor", "skill", "enemy", "result"):
+        v = data.get(key)
+        if isinstance(v, dict):
+            return [v]
+    return []
+
+
+def _first_numeric_id_from_row(row: Any, keys: tuple[str, ...]) -> int | None:
+    if not isinstance(row, dict):
+        return None
+    for k in keys:
+        if k not in row or row[k] is None:
+            continue
+        try:
+            return int(row[k])
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _row_name_matches_search_term(row: dict[str, Any], term: str) -> bool:
+    """검색어가 있을 때 MCP 행이 실제로 그 대상인지(이름 기준) 완화 검증한다."""
+    t = (term or "").strip().lower()
+    if not t:
+        return True
+    nm = str(row.get("name") or row.get("displayName") or "").strip().lower()
+    if not nm:
+        return False
+    return t in nm or nm == t
+
+
+def _items_local_search_by_name(data_path: Path, term: str) -> tuple[bool, int | None]:
+    """MCP가 hits를 안 주거나 exists를 안 넣어도 Items.json으로 존재 여부를 판별한다."""
+    t = (term or "").strip().lower()
+    if not t:
+        return False, None
+    fp = data_path / "Items.json"
+    if not fp.is_file():
+        return False, None
+    try:
+        raw = json.loads(fp.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False, None
+    if not isinstance(raw, list):
+        return False, None
+    for idx, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip().lower()
+        if not name:
+            continue
+        # 검색어가 이름의 부분 문자열일 때만 매칭 (name in term 은 'actor' in 'zzz_actor_…' 같은 오탐을 만든다)
+        if t in name:
+            rid = entry.get("id")
+            try:
+                return True, int(rid) if rid is not None else idx
+            except (TypeError, ValueError):
+                return True, idx
+    return False, None
+
+
+def _actors_local_search_by_name(data_path: Path, term: str) -> tuple[bool, int | None]:
+    t = (term or "").strip().lower()
+    if not t:
+        return False, None
+    fp = data_path / "Actors.json"
+    if not fp.is_file():
+        return False, None
+    try:
+        raw = json.loads(fp.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False, None
+    if not isinstance(raw, list):
+        return False, None
+    for idx, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip().lower()
+        if not name:
+            continue
+        if t in name:
+            rid = entry.get("id")
+            try:
+                return True, int(rid) if rid is not None else idx
+            except (TypeError, ValueError):
+                return True, idx
+    return False, None
+
+
+def _skills_local_search_by_name(data_path: Path, term: str) -> tuple[bool, int | None]:
+    t = (term or "").strip().lower()
+    if not t:
+        return False, None
+    fp = data_path / "Skills.json"
+    if not fp.is_file():
+        return False, None
+    try:
+        raw = json.loads(fp.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False, None
+    if not isinstance(raw, list):
+        return False, None
+    for idx, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip().lower()
+        if not name:
+            continue
+        if t in name:
+            rid = entry.get("id")
+            try:
+                return True, int(rid) if rid is not None else idx
+            except (TypeError, ValueError):
+                return True, idx
+    return False, None
+
+
+def _enrich_mcp_search_tool_result(
+    tool_name: str,
+    r: dict[str, Any],
+    *,
+    data_path: Path,
+    norm_args: dict[str, Any],
+) -> dict[str, Any]:
+    """조건부 create 스킵용으로 검색 MCP 결과에 exists·첫 id를 채운다.
+
+    Node MCP는 JSON에 exists를 안 넣는 경우가 많아, 성공(success)만으로는
+    '이미 있음 → create 생략'이 동작하지 않는다.
+    """
+    out = dict(r)
+    data = r.get("data")
+    st = str(
+        norm_args.get("searchTerm") or norm_args.get("search_term") or norm_args.get("query") or ""
+    ).strip()
+
+    cfg = {
+        "search_items": (("id", "itemId"), _items_local_search_by_name),
+        "search_actors": (("id", "actorId"), _actors_local_search_by_name),
+        "search_skills": (("id", "skillId"), _skills_local_search_by_name),
+    }
+    if tool_name not in cfg:
+        return out
+
+    id_keys, local_fn = cfg[tool_name]
+    rows = _coerce_list_from_mcp_search_payload(data)
+    first_id: int | None = None
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if not st:
+            # 빈 검색어로는 MCP 행을 신뢰하지 않는다(목록 전체가 올 수 있음).
+            continue
+        if not _row_name_matches_search_term(row, st):
+            continue
+        rid = _first_numeric_id_from_row(row, id_keys)
+        if rid is not None:
+            first_id = rid
+            break
+    # 빈 객체 리스트만 오거나 exists 플래그만 true인 경우 오판하지 않도록, id 확보 또는 로컬 매칭이 있을 때만 존재로 본다.
+    exists = first_id is not None
+
+    if not exists and st:
+        exists, first_id = local_fn(data_path, st)
+
+    out["exists"] = exists
+    if first_id is not None:
+        if tool_name == "search_items":
+            out["item_id"] = first_id
+        elif tool_name == "search_actors":
+            out["actor_id"] = first_id
+        elif tool_name == "search_skills":
+            out["skill_id"] = first_id
+    return out
+
+
+def _enrich_items_target_info_from_deps(
+    step: dict, step_results: dict[int, dict], target_info: dict[str, Any]
+) -> dict[str, Any]:
+    """선행 Items 검색 스텝에 item_id가 있으나 update 스텝에 빠진 경우 채운다."""
+    ti = dict(target_info)
+    if ti.get("item_id") is not None or ti.get("itemId") is not None:
+        return ti
+    for d in step.get("depends_on") or []:
+        try:
+            did = int(d)
+        except (TypeError, ValueError):
+            continue
+        prev = step_results.get(did)
+        if not isinstance(prev, dict):
+            continue
+        iid = prev.get("item_id")
+        if iid is not None:
+            ti["item_id"] = iid
+            logger.debug(
+                "[Executor] 선행 검색에서 item_id 보강 step=%s item_id=%s", step.get("step_id"), iid
+            )
+            break
+    return ti
+
+
 def _as_int(v: Any) -> Any:
     try:
         return int(v)
@@ -135,6 +347,10 @@ def _normalize_mcp_arguments(
         return out
 
     if target_file == "Actors.json" and action == "search":
+        if not (out.get("searchTerm") or out.get("search_term") or out.get("query")):
+            nm = out.get("actor_name") or out.get("name")
+            if nm is not None:
+                out["searchTerm"] = str(nm)
         return {"searchTerm": _search_term()}
 
     if target_file == "Actors.json" and action == "query_by_id":
@@ -166,6 +382,10 @@ def _normalize_mcp_arguments(
         return {"skillId": _as_int(sid)}
 
     if target_file == "Skills.json" and action == "search":
+        if not (out.get("searchTerm") or out.get("search_term") or out.get("query")):
+            nm = out.get("skill_name") or out.get("name")
+            if nm is not None:
+                out["searchTerm"] = str(nm)
         return {"searchTerm": _search_term()}
 
     if target_file == "Skills.json" and action == "update":
@@ -204,11 +424,27 @@ def _normalize_mcp_arguments(
 
     if target_file == "Items.json" and action == "update":
         iid = out.get("itemId", out.get("item_id"))
-        updates = out.get("updates")
-        built = {}
+        # 플래너가 updates 없이 new_description·damage 등만 줄 때가 많아 MCP 스키마용 updates로 합친다.
+        updates: dict[str, Any] = {}
+        if isinstance(out.get("updates"), dict):
+            updates = dict(out["updates"])
+        nd = out.get("new_description")
+        if nd is not None and "description" not in updates:
+            updates["description"] = str(nd)
+        desc = out.get("description")
+        if desc is not None and "description" not in updates:
+            updates["description"] = str(desc)
+        new_name = out.get("new_name") or out.get("newName")
+        if new_name is not None and "name" not in updates:
+            updates["name"] = str(new_name)
+        if isinstance(out.get("damage"), dict) and "damage" not in updates:
+            updates["damage"] = dict(out["damage"])
+        if isinstance(out.get("effects"), list) and "effects" not in updates:
+            updates["effects"] = list(out["effects"])
+        built: dict[str, Any] = {}
         if iid is not None:
             built["itemId"] = _as_int(iid)
-        if isinstance(updates, dict):
+        if updates:
             built["updates"] = updates
         return built
 
@@ -802,6 +1038,8 @@ async def _execute_one_structured_step(
     target_file = (step.get("target_file") or "").strip()
     target_info = step.get("target_info") if isinstance(step.get("target_info"), dict) else {}
     target_info = dict(target_info)
+    if target_file == "Items.json":
+        target_info = _enrich_items_target_info_from_deps(step, step_results, target_info)
     if target_file == "Actors.json":
         print(f"🔧 [EXECUTOR DEBUG] 액터 스텝 처리 시작: step_id={sid}")
         logger.warning("🔧 [EXECUTOR DEBUG] 액터 스텝 처리 시작: step_id=%s", sid)
@@ -864,23 +1102,39 @@ async def _execute_one_structured_step(
                     modified_files = r.get("modified_files") or mcp_entry.get(
                         "backup_files", [target_file]
                     )
+                    r_out = _enrich_mcp_search_tool_result(
+                        mcp_entry["tool"],
+                        r,
+                        data_path=data_path,
+                        norm_args=norm,
+                    )
                     logger.info(
-                        "[Executor] MCP 성공: step=%d, tool=%s, files=%s",
+                        "[Executor] MCP 성공: step=%d, tool=%s, files=%s exists=%s",
                         sid,
                         mcp_entry["tool"],
                         modified_files,
+                        r_out.get("exists"),
                     )
-                    step_results[sid] = {**r, "step_id": sid}
-                    return {
+                    step_results[sid] = {**r_out, "step_id": sid}
+                    entry: dict[str, Any] = {
                         "step_id": sid,
                         "tool_name": mcp_entry["tool"],
                         "success": True,
-                        "stdout": str(r.get("data", "")),
-                        "stderr": r.get("error") or "",
+                        "stdout": str(r_out.get("data", "")),
+                        "stderr": r_out.get("error") or "",
                         "modified_files": modified_files,
                         "structured": True,
                         "timestamp": ts,
                     }
+                    if "exists" in r_out:
+                        entry["exists"] = r_out["exists"]
+                    if r_out.get("item_id") is not None:
+                        entry["item_id"] = r_out["item_id"]
+                    if r_out.get("actor_id") is not None:
+                        entry["actor_id"] = r_out["actor_id"]
+                    if r_out.get("skill_id") is not None:
+                        entry["skill_id"] = r_out["skill_id"]
+                    return entry
                 logger.warning(
                     "[Executor] MCP 실패, 레거시 매니저로 폴백 step_id=%s err=%s",
                     sid,
@@ -1287,6 +1541,107 @@ async def _execute_one_structured_step(
         return result
 
 
+_ITEM_UPDATE_ID_KEYS = frozenset({"item_id", "itemId", "id"})
+
+
+def _enrich_execution_plan_items_from_modifications(
+    execution_plan: list[dict],
+    modifications: list[dict] | None,
+) -> list[dict]:
+    """Items.json update 스텝에 플래너가 빼먹은 필드를 Definition modifications.params에서 보강한다.
+
+    damage·effects뿐 아니라 price, description 등 Definition이 넣은 키를 동일 item_id 기준으로
+    target_info.updates에 오버레이한다(Definition 값이 우선).
+    """
+    if not modifications:
+        return execution_plan
+
+    mod_params_by_item_id: dict[int, dict[str, Any]] = {}
+    for m in modifications:
+        if not isinstance(m, dict):
+            continue
+        if m.get("type") != "update" or m.get("target") != "item":
+            continue
+        p = m.get("params")
+        if not isinstance(p, dict):
+            continue
+        raw_id = p.get("item_id") or p.get("itemId")
+        if raw_id in (None, "NEW"):
+            continue
+        try:
+            iid = int(raw_id)
+        except (TypeError, ValueError):
+            continue
+        mod_params_by_item_id[iid] = p
+
+    if not mod_params_by_item_id:
+        return execution_plan
+
+    enriched: list[dict] = []
+    for step in execution_plan:
+        if not isinstance(step, dict):
+            enriched.append(step)
+            continue
+        s = dict(step)
+        if s.get("target_file") != "Items.json":
+            enriched.append(s)
+            continue
+        if str(s.get("action_type") or "").lower() != "update":
+            enriched.append(s)
+            continue
+        ti = s.get("target_info")
+        if not isinstance(ti, dict):
+            enriched.append(s)
+            continue
+        ti = dict(ti)
+        raw_iid = ti.get("item_id") or ti.get("itemId")
+        try:
+            iid = int(raw_iid) if raw_iid is not None else None
+        except (TypeError, ValueError):
+            iid = None
+        if iid is None or iid not in mod_params_by_item_id:
+            enriched.append(s)
+            continue
+        src = mod_params_by_item_id[iid]
+
+        overlay_keys = [
+            k
+            for k in src
+            if k not in _ITEM_UPDATE_ID_KEYS and str(k).lower() not in ("item_id", "itemid")
+        ]
+        if not overlay_keys:
+            enriched.append(s)
+            continue
+
+        updates: dict[str, Any] = dict(ti["updates"]) if isinstance(ti.get("updates"), dict) else {}
+        merged = 0
+        for k in overlay_keys:
+            v = src[k]
+            if v is None:
+                continue
+            if isinstance(v, dict):
+                updates[k] = dict(v)
+            elif isinstance(v, list):
+                updates[k] = list(v)
+            else:
+                updates[k] = v
+            merged += 1
+
+        if merged == 0:
+            enriched.append(s)
+            continue
+
+        ti["updates"] = updates
+        s["target_info"] = ti
+        logger.info(
+            "[Executor] Items update에 Definition params 오버레이 | item_id=%s keys=%s",
+            iid,
+            sorted(updates.keys()),
+        )
+        enriched.append(s)
+    return enriched
+
+
 async def _executor_structured(
     data_path: Path,
     execution_plan: list[dict],
@@ -1540,7 +1895,12 @@ async def executor(state: AgentState) -> dict:
     # 이 포맷이면 LLM 번역 단계(레거시) 없이 곧바로 4단계 구조화 엔진으로 분기한다.
     if _is_structured_execution_plan(execution_plan):
         logger.info("[Executor] 구조화 플랜 분기: %d개 step", len(execution_plan))
-        result = await _executor_structured(data_path, execution_plan, game_id, retry_count)
+        mods = state.get("modifications")
+        plan_for_run = _enrich_execution_plan_items_from_modifications(
+            execution_plan,
+            mods if isinstance(mods, list) else None,
+        )
+        result = await _executor_structured(data_path, plan_for_run, game_id, retry_count)
 
         # 액터 관련 요청에서 실패가 있었는지 확인
         changes_log = result.get("changes_log", [])

--- a/agent/graph/nodes/executor.py
+++ b/agent/graph/nodes/executor.py
@@ -13,6 +13,7 @@ MVP 버전: 기존 dispatcher 재활용 + 기본 LLM 번역 + 백업/롤백
 """
 
 import asyncio
+import functools
 import json
 import logging
 import os
@@ -782,12 +783,29 @@ def _enrich_actors_target_info_from_deps(
     step_results: dict[int, dict],
     target_info: dict[str, Any],
 ) -> dict[str, Any]:
-    """선행 step(create/query 등)의 actor_id를 이어 받는다."""
+    """선행 step(create/query 등)의 actor_id를 이어 받는다.
+
+    플래너가 query→update에서 서로 다른 actor_id를 주는 경우(예: 설명은 미쉘인데 id=1),
+    선행 스텝의 step_results.actor_id가 있으면 update에서 그 값을 우선한다.
+    """
     ti = dict(target_info)
+    action = str(step.get("action_type") or "").lower()
+    dep_actor_id = None
+    for d in reversed(step.get("depends_on") or []):
+        try:
+            did = int(d)
+        except (TypeError, ValueError):
+            continue
+        prev = step_results.get(did)
+        if isinstance(prev, dict) and prev.get("actor_id") is not None:
+            dep_actor_id = prev["actor_id"]
+            break
+    if action == "update" and dep_actor_id is not None:
+        ti["actor_id"] = dep_actor_id
+
     if ti.get("actor_id") is not None or ti.get("actorId") is not None:
         return ti
-    deps = step.get("depends_on") or []
-    for d in reversed(deps):
+    for d in reversed(step.get("depends_on") or []):
         try:
             did = int(d)
         except (TypeError, ValueError):
@@ -802,22 +820,85 @@ def _enrich_actors_target_info_from_deps(
     return ti
 
 
+# update_actor: 플래너가 Actors.json 필드를 updates 밖 최상위에 둘 때 MCP updates로 합친다.
+_ACTOR_UPDATE_RESERVED_KEYS = frozenset(
+    {
+        "actor_id",
+        "actorId",
+        "actor_name",
+        "old_name",
+        "oldName",
+        "new_name",
+        "newName",
+        "class_name",
+        "id",
+        "updates",
+        "searchTerm",
+        "search_term",
+        "query",
+        "list_actors",
+        "list_all_actors",
+        "scope",
+        "description",
+        "condition",
+        "_context_corrected",
+    }
+)
+
+
+@functools.lru_cache(maxsize=1)
+def _actor_target_info_patch_field_names() -> frozenset[str]:
+    """agent.schemas.actors.Actor 기준 패치 허용 필드(MZ JSON camelCase). id는 슬롯 식별용이라 제외."""
+    from agent.schemas.actors import Actor
+
+    return frozenset(n for n in Actor.model_fields if n != "id")
+
+
+def _planner_key_to_actor_schema_field(key: str, allowed: frozenset[str]) -> str | None:
+    """camelCase 그대로 또는 snake_case → camelCase 로 Actor 필드명에 맞춘다."""
+    if key in allowed:
+        return key
+    if "_" not in key:
+        return None
+    parts = [p for p in key.split("_") if p]
+    if not parts:
+        return None
+    camel = parts[0].lower() + "".join(p[0].upper() + p[1:].lower() for p in parts[1:] if p)
+    return camel if camel in allowed else None
+
+
 def _coerce_actors_update_actor_target_info(target_info: dict[str, Any]) -> dict[str, Any]:
-    """update_actor용: updates 없이 new_name·name만 온 경우 MCP/매니저가 기대하는 형태로 맞춘다."""
+    """update_actor용: updates·이름 변경·최상위 Actor 스키마 필드를 MCP updates dict로 합친다."""
     ti = dict(target_info)
-    updates = ti.get("updates")
-    if isinstance(updates, dict) and updates:
-        return ti
+    merged: dict[str, Any] = {}
+    if isinstance(ti.get("updates"), dict):
+        merged.update(ti["updates"])
+
     aid = ti.get("actorId", ti.get("actor_id"))
     new_nm = str(ti.get("new_name") or ti.get("newName") or "").strip()
     old_nm = str(ti.get("actor_name") or ti.get("old_name") or ti.get("oldName") or "").strip()
     if new_nm and (aid is not None or old_nm):
-        ti["updates"] = {"name": new_nm}
-        return ti
-    nm = str(ti.get("name") or "").strip()
-    has_class = bool(str(ti.get("class_name") or "").strip()) or ti.get("class_id") is not None
-    if nm and aid is not None and not has_class:
-        ti["updates"] = {"name": nm}
+        merged["name"] = new_nm
+    else:
+        nm = str(ti.get("name") or "").strip()
+        has_class = bool(str(ti.get("class_name") or "").strip()) or ti.get("class_id") is not None
+        if nm and aid is not None and not has_class and "name" not in merged:
+            merged["name"] = nm
+
+    allowed = _actor_target_info_patch_field_names()
+    for k, v in ti.items():
+        if k in _ACTOR_UPDATE_RESERVED_KEYS:
+            continue
+        field = _planner_key_to_actor_schema_field(k, allowed)
+        if field is None:
+            continue
+        if field == "name" and "name" in merged:
+            continue
+        if v is not None:
+            merged[field] = v
+
+    if merged:
+        ti["updates"] = merged
     return ti
 
 
@@ -1108,6 +1189,10 @@ async def _execute_one_structured_step(
                         data_path=data_path,
                         norm_args=norm,
                     )
+                    if mcp_entry.get("tool") == "get_actor":
+                        aid_norm = norm.get("actorId") if norm else None
+                        if aid_norm is not None:
+                            r_out["actor_id"] = _as_int(aid_norm)
                     logger.info(
                         "[Executor] MCP 성공: step=%d, tool=%s, files=%s exists=%s",
                         sid,

--- a/agent/prompts/definition_prompt.py
+++ b/agent/prompts/definition_prompt.py
@@ -87,6 +87,20 @@ STEP5_SYSTEM_PROMPT = """당신은 수집된 정보를 바탕으로 RPG Maker MZ
    - `modifications` 내 `params`에는 반드시 `대상카테고리_id` 필드를 포함하십시오.
    - 신규 생성(CREATE)인 경우, ID는 반드시 **"NEW"**여야 합니다. (임의의 숫자를 지어내지 마십시오.)
    - 조회/수정(READ/UPDATE)인 경우, 식별된 **실제 숫자 ID**를 사용하십시오.
+6. **아이템(item)의 "효과" / 사용·전투 시 수치 변화 (범용 규칙, 매우 중요)**:
+   - **효과·데미지·피해·깎·회복·흡수·드레인·HP·MP·TP·상태이상·버프/디버프** 등 **플레이에 반영되는 변화**를 말하면, 이는 **설명(description)만 바꾸는 요청이 아닙니다.** 반드시 MZ 데이터 필드(`damage`, `effects`, 필요 시 `note` 등)로 표현하십시오.
+   - **`damage`**: 아이템의 "피해" 블록. 항상 객체로 넣고 필드는 `type`, `elementId`, `formula`, `variance`, `critical`를 맞추십시오.
+     - **`damage.type` (0~6, MZ 관례)**: 0=없음, 1=HP 피해, 2=MP 피해, 3=HP 회복, 4=MP 회복, 5=HP 흡수, 6=MP 흡수. 사용자 의도에 맞는 타입을 고르십시오(예: "MP를 깎는다"→2, "MP를 채운다"→4).
+     - **`damage.formula`**: 런타임 계산식. 허용 토큰 예: `a.atk`, `a.def`, `a.mat`, `a.agi`, `a.luk`, `b.mhp`, `b.def`, `b.hp`, `b.mp`, 숫자, `+ - * / ( )`. **의도를 설명 문장으로만 남기지 말고** 수식으로 옮기십시오.
+       - 고정 피해 50: `type: 1`, `formula: "50"`.
+       - 최대 HP의 비율 등은 `b.mhp`와 연산으로 표현(예: 최대 HP의 30% 피해 → `"b.mhp * 0.3"` 등, 문맥에 맞게).
+       - **남은 HP가 정확히 1이 되게**: HP 피해 `type: 1`, `formula: "b.hp - 1"`, `variance: 0`, `critical: false` (단순 `"1"`은 "피해량 1"이지 "남김 1"이 아님).
+       - **완전 회복 성격**(수식으로 전체 회복): `type: 3`, `formula: "b.mhp"` 또는 문맥에 맞는 회복량.
+       - **고정량 HP 회복**(예: "HP를 3 늘려"): `type: 3`, `formula: "3"` 이 가장 단순합니다. 기존 데이터가 MP 회복만 `effects`(code 12)로 두었다면, 동일 프로젝트 관례에 맞춰 **HP는 code 11**로 `effects`에 옮기거나 `damage`와 `effects`를 정리해 **의도한 수치가 실제로 적용되게** 맞추십시오.
+     - **`variance` / `critical`**: 고정값을 원하면 `variance: 0`, 치명타 없음이면 `critical: false`.
+   - **`effects`**: "사용 효과" 배열. **고정 수치 HP/MP/TP 회복**, **상태 부여·해제**, **일시 강화/약화** 등은 `damage`만으로 표현하기 어색할 때 `effects`의 `code`, `dataId`, `value1`, `value2`로 넣으십시오. (예: HP 회복 code 11, MP 회복 12, 상태 추가 21 등 — 스키마·레퍼런스의 허용 코드를 따름.)
+   - **동시 사용**: 한 아이템이 "피해 + 상태 부여"처럼 복합이면 `damage`와 `effects`를 함께 채울 수 있습니다.
+   - **설명만 바꾸라고 명시**한 경우에 한해 `description`(및 요청된 다른 문자열 필드)만 수정합니다.
 """
 
 

--- a/agent/prompts/planner_prompt.py
+++ b/agent/prompts/planner_prompt.py
@@ -77,7 +77,7 @@ _SYSTEM_PROMPT = """\
    - 전체 목록만 필요하면 Actors.json·Skills.json·Items.json 등에 `list` 사용
    - 이름 부분 일치 검색은 `search` + target_info에 searchTerm(또는 query)
    - Actors.json에서 query만 써야 할 때: ID 조회는 actor_id, 이름 존재 확인은 actor_name/name, 전체 목록은 target_info에 list_actors=true, 부분 검색은 searchTerm만(이름 키 없이)
-   - Actors.json 수정: 생성 직후 같은 흐름에서 수정하면 depends_on으로 이어 주고, target_info에 actor_id를 반복하지 않아도 됨(Executor가 선행 step의 actor_id를 채움). 이름 변경은 actor_id+new_name 또는 actor_name+new_name, 일반 필드는 updates+actor_id
+   - Actors.json 수정: 생성 직후 같은 흐름에서 수정하면 depends_on으로 이어 주고, target_info에 actor_id를 반복하지 않아도 됨(Executor가 선행 step의 actor_id를 채움). 이름 변경은 actor_id+new_name 또는 actor_name+new_name. **일반 속성**(maxLevel, nickname, faceIndex, equips, traits 등)은 **`updates` 객체**에 넣거나, **Actor 스키마와 같은 camelCase 필드명**(또는 `max_level` 같은 snake_case)을 **target_info 최상위**에 둘 수 있음(Executor가 `update_actor`용으로 합침).
 
 ### 응답 순서 (Chain-of-Thought)
 반드시 아래 순서로 사고하고 출력할 것:

--- a/agent/prompts/planner_prompt.py
+++ b/agent/prompts/planner_prompt.py
@@ -29,7 +29,7 @@ _SYSTEM_PROMPT = """\
 | Actors.json | 플레이어 캐릭터 | classId→Classes, equips[]→Weapons/Armors, traits[] |
 | Classes.json | 직업 | learnings[].skillId→Skills, traits[] |
 | Skills.json | 스킬 | stypeId→System.skillTypes, damage.elementId→System.elements, effects[code=21].dataId→States, requiredWtypeId1→System.weaponTypes, requiredWtypeId2→System.weaponTypes, animationId→Animations |
-| Items.json | 아이템 | damage.elementId→System.elements, animationId→Animations |
+| Items.json | 아이템 | **사용 시 피해/회복은 `damage` 객체**(type, formula 등). damage.elementId→System.elements, animationId→Animations |
 | Weapons.json | 무기 | wtypeId→System.weaponTypes, etypeId→System.equipTypes(고정=1), animationId→Animations, traits[] |
 | Armors.json | 방어구 | atypeId→System.armorTypes, etypeId→System.equipTypes(2~5), traits[] |
 | Enemies.json | 적 | actions[].skillId→Skills, dropItems[kind=1].dataId→Items, dropItems[kind=2].dataId→Weapons, dropItems[kind=3].dataId→Armors, traits[] |
@@ -55,6 +55,15 @@ _SYSTEM_PROMPT = """\
 - 파일 구조의 참조 관계를 따라 연쇄적으로 관련 엔티티를 조회/생성하지 말 것
 - 사용자가 언급하지 않은 엔티티(직업, 무기, 방어구 등)는 계획에 포함하지 말 것
 - 판단 기준: "이 step이 없으면 사용자의 요청을 완료할 수 없는가?" → 아니라면 제외
+
+### Items.json 수정 (효과 vs 설명)
+- **이름이 정해진 기존 아이템**(예: "매직 워터")의 효과·수치만 바꾸는 요청에는 **`Items.json` `create` 스텝을 넣지 마십시오.** 검색(`query`/`search`) 후 **`update` 한 번**(또는 ID가 이미 있으면 검색 생략)으로 끝내십시오. "없으면 생성" 패턴은 **신규 아이템을 사용자가 명시적으로 만들 때만** 사용합니다.
+- 사용자가 **아이템 효과·데미지·피해·회복·흡수·HP/MP/TP·상태이상·버프** 등 **플레이 수치·메커닉**을 말하면 `target_info`에 **`updates`**를 두고, Definition과 동일하게 **`damage`** (`type`, `elementId`, `formula`, `variance`, `critical`) 및 필요 시 **`effects`** 배열을 넣으십시오. 이는 **`new_description`만 바꾸는 작업이 아닙니다.**
+- **고정량 HP 회복**(예: "HP를 3 늘려")은 `damage.type: 3`, `formula: "3"` 조합 또는 **`effects`**의 HP 회복(code 11) 등 MZ·스키마에 맞는 방식으로 표현하십시오(MP 회복 포션과 동일하게 `value` 필드 조합을 쓰는 경우가 많음).
+- **`damage.type`**: 0=없음, 1=HP 피해, 2=MP 피해, 3=HP 회복, 4=MP 회복, 5=HP 흡수, 6=MP 흡수. 요청 문장에 맞게 선택하십시오.
+- **`formula`**: `b.hp`, `b.mp`, `b.mhp`, `b.def` 등과 숫자·연산자로 의도를 수식화하십시오. "남은 HP 1"류는 예: `"formula": "b.hp - 1"`, `type: 1`, `variance: 0`, `critical: false`.
+- Definition `modifications[].params`에 있는 **아이템 관련 필드 전체**(예: `damage`, `effects`, `price`, `consumable` 등)가 실행에 필요하면 **`updates`에 빠짐없이 반영**하십시오. Executor가 Definition을 보강할 수 있으나, 플래너가 처음부터 맞추는 것이 안전합니다.
+- `item_id`(또는 Definition과 동일한 ID)는 `target_info`에 유지합니다.
 
 ### 작업 규칙
 1. 각 step은 단일 원자 작업으로 쪼갤 것

--- a/agent/schemas/items.py
+++ b/agent/schemas/items.py
@@ -21,7 +21,8 @@ class Damage(BaseModel):
         if v == "0":
             return v
 
-        token_pattern = r"(?:a|b)\.(?:atk|def|mhp|mat)|\d+(?:\.\d+)?|[+\-*/()]|\s+"
+        # MZ 런타임은 b.hp, b.mp 등을 널리 사용한다(예: 남은 HP 1 만들기 → b.hp - 1).
+        token_pattern = r"(?:a|b)\.(?:atk|def|mhp|mat|hp|mp|luk|agi)|\d+(?:\.\d+)?|[+\-*/()]|\s+"
         consumed = "".join(m.group(0) for m in re.finditer(token_pattern, v))
 
         if consumed != v:

--- a/agent/tests/test_executor_mvp.py
+++ b/agent/tests/test_executor_mvp.py
@@ -356,6 +356,82 @@ async def test_structured_mcp_alias_actor_update_routes_update_actor(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_structured_mcp_actor_update_merges_top_level_max_level(monkeypatch):
+    """플래너가 maxLevel을 updates 밖에 두어도 update_actor 인자에 합쳐진다."""
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+
+    called: dict[str, object] = {}
+
+    async def fake_call_mcp_tool(tool_name, arguments, data_path, path_arg_name="targetDir"):
+        called["tool_name"] = tool_name
+        called["arguments"] = dict(arguments or {})
+        return {"success": True, "data": {"ok": True}, "modified_files": ["Actors.json"]}
+
+    monkeypatch.setattr(executor_module, "is_mcp_enabled", lambda: True)
+    monkeypatch.setattr(executor_module, "build_stdio_server_parameters", lambda: object())
+    monkeypatch.setattr(executor_module, "call_mcp_tool", fake_call_mcp_tool)
+
+    state: AgentState = {
+        "execution_plan": [
+            {
+                "step_id": 1,
+                "description": "maxLevel만 최상위로 준 업데이트",
+                "action_type": "update",
+                "target_file": "Actors.json",
+                "target_info": {"actor_id": 4, "maxLevel": 77},
+                "depends_on": [],
+                "condition": "",
+            }
+        ],
+        "game_id": "game_001",
+        "retry_count": 0,
+    }
+
+    result = await executor(state)
+    log = result["changes_log"][0]
+    assert log["tool_name"] == "update_actor"
+    assert called["arguments"] == {"actorId": 4, "updates": {"maxLevel": 77}}
+
+
+@pytest.mark.asyncio
+async def test_structured_mcp_actor_update_snake_case_maps_to_schema(monkeypatch):
+    """snake_case 키는 Actor 스키마 camelCase로 매핑되어 updates에 들어간다."""
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+
+    called: dict[str, object] = {}
+
+    async def fake_call_mcp_tool(tool_name, arguments, data_path, path_arg_name="targetDir"):
+        called["arguments"] = dict(arguments or {})
+        return {"success": True, "data": {"ok": True}, "modified_files": ["Actors.json"]}
+
+    monkeypatch.setattr(executor_module, "is_mcp_enabled", lambda: True)
+    monkeypatch.setattr(executor_module, "build_stdio_server_parameters", lambda: object())
+    monkeypatch.setattr(executor_module, "call_mcp_tool", fake_call_mcp_tool)
+
+    state: AgentState = {
+        "execution_plan": [
+            {
+                "step_id": 1,
+                "description": "snake_case 필드",
+                "action_type": "update",
+                "target_file": "Actors.json",
+                "target_info": {"actor_id": 2, "initial_level": 10, "face_index": 5},
+                "depends_on": [],
+                "condition": "",
+            }
+        ],
+        "game_id": "game_001",
+        "retry_count": 0,
+    }
+
+    await executor(state)
+    assert called["arguments"] == {
+        "actorId": 2,
+        "updates": {"initialLevel": 10, "faceIndex": 5},
+    }
+
+
+@pytest.mark.asyncio
 async def test_structured_mcp_alias_system_update_game_title(monkeypatch):
     """System update + game_title이 MCP update_game_title로 정규화되는지 검증."""
     executor_module = importlib.import_module("agent.graph.nodes.executor")

--- a/agent/tests/test_executor_mvp.py
+++ b/agent/tests/test_executor_mvp.py
@@ -101,8 +101,12 @@ async def test_executor_mvp():
     print("\n🎉 MVP 테스트 완료")
 
 
-async def test_structured_execution_plan_actors():
+async def test_structured_execution_plan_actors(monkeypatch):
     """3단계 구조화 execution_plan: Actors.json query → 조건부 create."""
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    # MCP stdio는 테스트용 game_001과 파일 동기화가 어긋날 수 있어, 이 시나리오는 레거시 ActorManager로 고정 검증한다.
+    monkeypatch.setattr(executor_module, "is_mcp_enabled", lambda: False)
+
     unique_name = f"ZZZ_EXECUTOR_STRUCT_TEST_{uuid.uuid4().hex[:8]}"
     state: AgentState = {
         "execution_plan": [
@@ -155,8 +159,11 @@ async def test_structured_execution_plan_actors():
     assert any("존재" in (x.get("skip_reason") or "") for x in skipped)
 
 
-async def test_structured_execution_plan_full_update_flow():
+async def test_structured_execution_plan_full_update_flow(monkeypatch):
     """Classes/Actors/System 연계 query-create-update가 모두 동작하는지 검증."""
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    monkeypatch.setattr(executor_module, "is_mcp_enabled", lambda: False)
+
     unique_suffix = uuid.uuid4().hex[:8]
     class_name = f"ZZZ_CLASS_{unique_suffix}"
     actor_name = f"ZZZ_ACTOR_{unique_suffix}"
@@ -959,6 +966,35 @@ async def test_executor_returns_empty_modified_file_paths_for_read_only_query(mo
     result = await executor(state)
 
     assert result["modified_file_paths"] == []
+
+
+def test_search_items_mcp_enrichment_sets_exists_from_items_json(tmp_path):
+    """MCP가 hits 리스트를 안 줘도 Items.json 로컬 검색으로 exists·item_id를 채운다."""
+    import importlib
+    import json
+
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+
+    items = [
+        None,
+        {"id": 9, "name": "기타"},
+        {"id": 10, "name": "매직 워터"},
+    ]
+    (tmp_path / "Items.json").write_text(json.dumps(items, ensure_ascii=False), encoding="utf-8")
+
+    ex, iid = executor_module._items_local_search_by_name(tmp_path, "매직")
+    assert ex is True
+    assert iid == 10
+
+    r = {"success": True, "data": {"found": False}, "modified_files": []}
+    out = executor_module._enrich_mcp_search_tool_result(
+        "search_items",
+        r,
+        data_path=tmp_path,
+        norm_args={"searchTerm": "매직 워터"},
+    )
+    assert out["exists"] is True
+    assert out["item_id"] == 10
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1번째 문제 MCP 검색 exists 보강, Items 플랜/업데이트 일반화, damage formula 토큰 확장

Executor에서 search_items·search_actors·search_skills 성공 후에도 exists/id가 비어 조건부 create가 잘못 도는 문제를 막기
MCP JSON에서 id를 쓸 때는 검색어와 name이 맞을 때만 인정하고, 실패 시 data 폴더의 JSON으로 로컬 이름 검색 
Actors·Skills 검색 시 actor_name·skill_name을 searchTerm으로 넘기도록 정규화
Items update는 선행 검색의 item_id를 보강하고, Definition params를 damage/effects뿐 아니라 전 필드오버레이
플래너·Definition 프롬프트는 기존 아이템 효과 변경 시 create·설명만 수정을 피하고 HP 고정 회복을 damage/effects로 쓰도록 안내
Items Damage formula에 b.hp·b.mp등을 허용
Executor MVP 테스트에 검색 보강 단위 테스트를 추가하고, Actors 연계시나리오는 MCP 비활성으로 안정화

2번째 문제 Actors update_actor 스키마 기반 필드 병합 및 query→update actor_id 정합
- Executor: update 스텝에서 depends_on 선행 결과의 actor_id를 우선해 플래너 ID 오류를 완화한다.
- get_actor MCP 성공 시 norm의 actorId를 step_results.actor_id로 남긴다.
- _coerce_actors_update_actor_target_info가 Actor 모델 필드 전부( id 제외 )를 최상위·snake_case에서 updates로 합친다.
- Planner에 Actors 수정 시 updates 또는 최상위 스키마 필드 사용을 안내한다.
- 상위 maxLevel·snake_case 필드 병합 테스트를 추가한다.