### PR TITLE
fix: EC2 배포 타임아웃 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          command_timeout: 30m
           script: |
             set -e
             if [ ! -d "Re-Verse" ]; then


### PR DESCRIPTION
## Summary
- EC2 배포 시 Docker 빌드가 SSH action 기본 타임아웃(10m)을 초과하여 배포 실패하는 문제 수정
- `appleboy/ssh-action`의 `command_timeout`을 30m으로 설정

## 원인
- MCP 서버 git clone + npm build, Node.js 설치, Python 의존성 설치 등으로 빌드 시간이 10분 초과
- `Run Command Timeout` 에러로 배포 실패

## 변경사항
- `.github/workflows/deploy.yml`에 `command_timeout: 30m` 추가