### PR TITLE
test: agent/backend 테스트 코드 및 커버리지 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,8 @@ jobs:
         run: uv run mypy app/backend agent
         continue-on-error: true  # 초기 단계에서는 경고로만
 
-      - name: Run tests (pytest)
-        run: uv run pytest app/backend/tests agent/tests -v --tb=short
-        continue-on-error: true  # 테스트 파일이 채워지기 전까지 경고로만
+      - name: Run tests (pytest — LLM 통합테스트 제외)
+        run: uv run pytest app/backend/tests agent/tests -v --tb=short -m "not integration"
 
   # =========================================================
   # Job 2: Frontend CI (React / Vite)

--- a/README.md
+++ b/README.md
@@ -150,14 +150,45 @@ npm run dev
 
 ## 🧪 테스트 & 품질 체크
 
-루트에서:
+### Agent 테스트
 
 ```bash
-uv run pytest
+# 전체 실행
+python -m pytest agent/tests/ -v
+
+# 커버리지 포함
+python -m pytest agent/tests/ --cov --cov-report=term-missing
+
+# 특정 파일만
+python -m pytest agent/tests/test_executor_mvp.py -v
+
+# 키워드 필터
+python -m pytest agent/tests/ -k "enemy" -v
+```
+
+### Backend 테스트
+
+```bash
+# 전체 실행
+python -m pytest app/backend/tests/ -v
+
+# 커버리지 포함
+python -m pytest app/backend/tests/ --cov --cov-report=term-missing
+```
+
+### 전체 테스트 + 커버리지
+
+```bash
+python -m pytest --cov --cov-report=term-missing
+```
+
+### 린트
+
+```bash
 uv run ruff check .
 ```
 
-프론트에서:
+### 프론트엔드
 
 ```bash
 cd app/frontend

--- a/agent/graph/nodes/definition.py
+++ b/agent/graph/nodes/definition.py
@@ -68,6 +68,39 @@ SUPPORTED_BULK_TARGETS = {
 UNSUPPORTED_BULK_TARGETS = {"skill"}
 
 
+def filter_category_labels(classifications: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """지칭어(is_category_label)와 구체 이름이 섞여 있을 때 지칭어를 제거한다.
+
+    규칙:
+    1. 구체 이름(non-label)이 하나라도 있으면, 모든 카테고리 지칭어를 제거한다.
+       예: "루시퍼 액터 추가" → '루시퍼'는 유지, '액터'(지칭어)는 제거.
+    2. 동일 카테고리에 구체 이름과 지칭어가 공존하면, 지칭어를 제거한다.
+    3. 지칭어만 있으면(예: "액터 전부 삭제") 그대로 유지한다.
+    """
+    categories_with_real_names = {
+        cls["category"] for cls in classifications if not cls.get("is_category_label")
+    }
+    has_non_label_entity = any(not c.get("is_category_label") for c in classifications)
+
+    result: list[dict[str, Any]] = []
+    for cls in classifications:
+        if cls.get("is_category_label") and has_non_label_entity:
+            logger.info(
+                "[Definition] 구체 대상이 있어 카테고리 지칭어 분류 제외: %s",
+                cls.get("name"),
+            )
+            continue
+        if cls.get("is_category_label") and cls["category"] in categories_with_real_names:
+            logger.info(
+                "[Definition] 중복 지칭어 제거: %s (카테고리 %s에 구체적 대상 존재)",
+                cls["name"],
+                cls["category"],
+            )
+            continue
+        result.append(cls)
+    return result
+
+
 def _normalize_category_to_plural(cat: str) -> str:
     """단수형 카테고리를 RPG Maker MZ 파일용 복수형으로 변환 (예: Enemy -> Enemies)"""
     return CATEGORY_TO_PLURAL.get(cat.lower(), cat.capitalize())
@@ -597,30 +630,7 @@ async def definition(state: AgentState) -> dict:
         logger.debug("[Definition] 분류 사유: %s", cls["reason"])
 
     # --- [4.5단계: 중복 및 지칭어 필터링] ---
-    # 동일 카테고리에 구체적인 이름이 있는 엔티티와 '지칭어'가 섞여있으면 지칭어 제거
-    final_classifications = []
-    categories_with_real_names = {
-        cls["category"] for cls in classifications if not cls.get("is_category_label")
-    }
-    has_non_label_entity = any(not c.get("is_category_label") for c in classifications)
-
-    for cls in classifications:
-        # "루시퍼 액터 추가"처럼 구체 이름이 있는데 '액터'만 category=None 지칭어로 남는 경우 제거
-        if cls.get("is_category_label") and has_non_label_entity:
-            logger.info(
-                "[Definition] 구체 대상이 있어 카테고리 지칭어 분류 제외: %s",
-                cls.get("name"),
-            )
-            continue
-        # 지칭어인데 해당 카테고리에 이미 구체적인 이름의 엔티티가 있다면 제외
-        if cls.get("is_category_label") and cls["category"] in categories_with_real_names:
-            logger.info(
-                "[Definition] 중복 지칭어 제거: %s (카테고리 %s에 구체적 대상 존재)",
-                cls["name"],
-                cls["category"],
-            )
-            continue
-        final_classifications.append(cls)
+    final_classifications = filter_category_labels(classifications)
 
     # --- [5단계: 최종 조립 (Specification)] ---
     logger.info("[Definition] Step 5: 최종 수정 명세 생성 중...")

--- a/agent/graph/nodes/executor.py
+++ b/agent/graph/nodes/executor.py
@@ -1958,7 +1958,9 @@ async def _execute_one_structured_step(
             if target_info.get("item_id") is not None or target_info.get("itemId") is not None:
                 logger.debug("[Executor] 구조화: Items.json.create → JSON 직접 저장")
                 async with game_locks[game_id]:
-                    r = await asyncio.to_thread(_structured_create_item_sync, data_path, target_info)
+                    r = await asyncio.to_thread(
+                        _structured_create_item_sync, data_path, target_info
+                    )
                 step_results[sid] = {**r, "step_id": sid}
                 mf = r.get("modified_files") or ["Items.json"]
                 return {
@@ -1976,7 +1978,9 @@ async def _execute_one_structured_step(
             if target_info.get("enemy_id") is not None or target_info.get("enemyId") is not None:
                 logger.debug("[Executor] 구조화: Enemies.json.create → JSON 직접 저장")
                 async with game_locks[game_id]:
-                    r = await asyncio.to_thread(_structured_create_enemy_sync, data_path, target_info)
+                    r = await asyncio.to_thread(
+                        _structured_create_enemy_sync, data_path, target_info
+                    )
                 step_results[sid] = {**r, "step_id": sid}
                 mf = r.get("modified_files") or ["Enemies.json"]
                 return {

--- a/agent/graph/nodes/executor.py
+++ b/agent/graph/nodes/executor.py
@@ -1957,7 +1957,8 @@ async def _execute_one_structured_step(
         if target_file == "Items.json" and action == "create":
             if target_info.get("item_id") is not None or target_info.get("itemId") is not None:
                 logger.debug("[Executor] 구조화: Items.json.create → JSON 직접 저장")
-                r = await asyncio.to_thread(_structured_create_item_sync, data_path, target_info)
+                async with game_locks[game_id]:
+                    r = await asyncio.to_thread(_structured_create_item_sync, data_path, target_info)
                 step_results[sid] = {**r, "step_id": sid}
                 mf = r.get("modified_files") or ["Items.json"]
                 return {
@@ -1974,7 +1975,8 @@ async def _execute_one_structured_step(
         if target_file == "Enemies.json" and action == "create":
             if target_info.get("enemy_id") is not None or target_info.get("enemyId") is not None:
                 logger.debug("[Executor] 구조화: Enemies.json.create → JSON 직접 저장")
-                r = await asyncio.to_thread(_structured_create_enemy_sync, data_path, target_info)
+                async with game_locks[game_id]:
+                    r = await asyncio.to_thread(_structured_create_enemy_sync, data_path, target_info)
                 step_results[sid] = {**r, "step_id": sid}
                 mf = r.get("modified_files") or ["Enemies.json"]
                 return {

--- a/agent/rag/embeddings.py
+++ b/agent/rag/embeddings.py
@@ -28,5 +28,24 @@ class RPGEmbeddings:
         return self.query_model.embed_query(text)
 
 
-# 싱글톤 인스턴스
-upstage_embeddings = RPGEmbeddings()
+# 싱글톤 — lazy 초기화 (import 시점에 API 키 없어도 에러 안 남)
+_instance: RPGEmbeddings | None = None
+
+
+def get_embeddings() -> RPGEmbeddings:
+    """최초 호출 시 RPGEmbeddings 인스턴스 생성. API 키 없으면 이 시점에 에러."""
+    global _instance
+    if _instance is None:
+        _instance = RPGEmbeddings()
+    return _instance
+
+
+# 하위호환: 기존 코드에서 upstage_embeddings 직접 참조하는 곳 대응
+class _LazyProxy:
+    """속성 접근 시점에 실제 인스턴스 생성."""
+
+    def __getattr__(self, name: str):
+        return getattr(get_embeddings(), name)
+
+
+upstage_embeddings = _LazyProxy()

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -1,0 +1,43 @@
+"""agent/tests 공유 pytest fixture.
+
+backend conftest가 STORAGE_PATH를 임시 디렉토리로 패치하는 경우,
+agent 테스트에서 실제 게임 데이터가 필요할 때를 위해
+base_game/data/를 임시 STORAGE_PATH/game_001/data/에 복사한다.
+
+agent 테스트만 단독 실행할 때(backend conftest 미로드)는
+STORAGE_PATH가 실제 경로이므로 복사하지 않는다.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_BASE_GAME_DATA = _PROJECT_ROOT / "storage" / "games" / "base_game" / "data"
+_REAL_STORAGE = _PROJECT_ROOT / "storage" / "games"
+
+
+@pytest.fixture(autouse=True)
+def _ensure_test_game_data():
+    """매 테스트마다 STORAGE_PATH의 game_001/data/를 base_game에서 초기화.
+
+    단, STORAGE_PATH가 실제 프로젝트 경로면 이미 데이터가 있으므로 건너뛴다.
+    임시 디렉토리(backend conftest)인 경우에만 복사한다.
+    """
+    from app.backend.core.config import settings
+
+    storage_path = Path(settings.STORAGE_PATH).resolve()
+
+    # 실제 프로젝트 storage 경로면 복사 불필요 (agent 단독 실행 시)
+    if storage_path == _REAL_STORAGE.resolve():
+        return
+
+    # 임시 디렉토리인 경우에만 base_game에서 복사
+    test_data = storage_path / "game_001" / "data"
+    if _BASE_GAME_DATA.exists():
+        if test_data.exists():
+            shutil.rmtree(test_data)
+        shutil.copytree(_BASE_GAME_DATA, test_data)

--- a/agent/tests/test_executor_helpers.py
+++ b/agent/tests/test_executor_helpers.py
@@ -9,8 +9,6 @@ import importlib
 import json
 from pathlib import Path
 
-import pytest
-
 executor_module = importlib.import_module("agent.graph.nodes.executor")
 
 
@@ -190,7 +188,8 @@ class TestNormalizeMcpArguments:
 
     def test_actors_update_actor(self) -> None:
         result = self.fn(
-            "Actors.json", "update_actor",
+            "Actors.json",
+            "update_actor",
             {"actor_id": 1, "updates": {"maxLevel": 99}},
         )
         assert result == {"actorId": 1, "updates": {"maxLevel": 99}}
@@ -205,7 +204,8 @@ class TestNormalizeMcpArguments:
 
     def test_items_update_merges_fields(self) -> None:
         result = self.fn(
-            "Items.json", "update",
+            "Items.json",
+            "update",
             {"item_id": 5, "new_description": "Good potion", "new_name": "Hi-Potion"},
         )
         assert result["itemId"] == 5

--- a/agent/tests/test_executor_helpers.py
+++ b/agent/tests/test_executor_helpers.py
@@ -1,0 +1,239 @@
+"""executor.py 내 순수 헬퍼 함수 테스트.
+
+LLM/MCP 호출 없이 dict 변환, 리스트 정규화, 로컬 검색 등을 검증한다.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+executor_module = importlib.import_module("agent.graph.nodes.executor")
+
+
+# ── _coerce_list_from_mcp_search_payload ─────────────────────
+
+
+class TestCoerceListFromMcpSearchPayload:
+    fn = staticmethod(executor_module._coerce_list_from_mcp_search_payload)
+
+    def test_none_returns_empty(self) -> None:
+        assert self.fn(None) == []
+
+    def test_list_passthrough(self) -> None:
+        assert self.fn([1, 2]) == [1, 2]
+
+    def test_non_dict_non_list_returns_empty(self) -> None:
+        assert self.fn("string") == []
+        assert self.fn(42) == []
+
+    def test_dict_with_items_key(self) -> None:
+        assert self.fn({"items": [{"id": 1}]}) == [{"id": 1}]
+
+    def test_dict_with_results_key(self) -> None:
+        assert self.fn({"results": [{"id": 2}]}) == [{"id": 2}]
+
+    def test_dict_with_singular_key(self) -> None:
+        assert self.fn({"item": {"id": 1}}) == [{"id": 1}]
+
+    def test_dict_no_known_keys(self) -> None:
+        assert self.fn({"foo": "bar"}) == []
+
+
+# ── _first_numeric_id_from_row ───────────────────────────────
+
+
+class TestFirstNumericIdFromRow:
+    fn = staticmethod(executor_module._first_numeric_id_from_row)
+
+    def test_finds_id(self) -> None:
+        assert self.fn({"id": 5, "name": "x"}, ("id",)) == 5
+
+    def test_string_id_coerced(self) -> None:
+        assert self.fn({"actorId": "3"}, ("actorId",)) == 3
+
+    def test_none_value_skipped(self) -> None:
+        assert self.fn({"id": None, "actorId": 7}, ("id", "actorId")) == 7
+
+    def test_non_dict_returns_none(self) -> None:
+        assert self.fn("not a dict", ("id",)) is None
+
+    def test_no_matching_key(self) -> None:
+        assert self.fn({"name": "x"}, ("id", "actorId")) is None
+
+    def test_non_numeric_value(self) -> None:
+        assert self.fn({"id": "abc"}, ("id",)) is None
+
+
+# ── _row_name_matches_search_term ────────────────────────────
+
+
+class TestRowNameMatchesSearchTerm:
+    fn = staticmethod(executor_module._row_name_matches_search_term)
+
+    def test_exact_match(self) -> None:
+        assert self.fn({"name": "Hero"}, "Hero") is True
+
+    def test_partial_match(self) -> None:
+        assert self.fn({"name": "Fire Ball"}, "fire") is True
+
+    def test_no_match(self) -> None:
+        assert self.fn({"name": "Ice"}, "fire") is False
+
+    def test_empty_term_always_true(self) -> None:
+        assert self.fn({"name": "anything"}, "") is True
+
+    def test_empty_name_returns_false(self) -> None:
+        assert self.fn({"name": ""}, "hero") is False
+
+    def test_display_name_fallback(self) -> None:
+        assert self.fn({"displayName": "Shadow"}, "shadow") is True
+
+
+# ── _items_local_search_by_name ──────────────────────────────
+
+
+class TestItemsLocalSearchByName:
+    fn = staticmethod(executor_module._items_local_search_by_name)
+
+    def test_found(self, tmp_path: Path) -> None:
+        dp = tmp_path / "data"
+        dp.mkdir()
+        items = [None, {"id": 1, "name": "Potion"}, {"id": 2, "name": "Elixir"}]
+        (dp / "Items.json").write_text(json.dumps(items), encoding="utf-8")
+        exists, item_id = self.fn(dp, "potion")
+        assert exists is True
+        assert item_id == 1
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        dp = tmp_path / "data"
+        dp.mkdir()
+        items = [None, {"id": 1, "name": "Potion"}]
+        (dp / "Items.json").write_text(json.dumps(items), encoding="utf-8")
+        exists, _ = self.fn(dp, "sword")
+        assert exists is False
+
+    def test_empty_term(self, tmp_path: Path) -> None:
+        dp = tmp_path / "data"
+        dp.mkdir()
+        exists, _ = self.fn(dp, "")
+        assert exists is False
+
+    def test_file_missing(self, tmp_path: Path) -> None:
+        dp = tmp_path / "data"
+        dp.mkdir()
+        exists, _ = self.fn(dp, "potion")
+        assert exists is False
+
+
+# ── _actors_local_search_by_name ─────────────────────────────
+
+
+class TestActorsLocalSearchByName:
+    fn = staticmethod(executor_module._actors_local_search_by_name)
+
+    def test_found(self, tmp_path: Path) -> None:
+        dp = tmp_path / "data"
+        dp.mkdir()
+        actors = [None, {"id": 1, "name": "Hero"}]
+        (dp / "Actors.json").write_text(json.dumps(actors), encoding="utf-8")
+        exists, aid = self.fn(dp, "hero")
+        assert exists is True
+        assert aid == 1
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        dp = tmp_path / "data"
+        dp.mkdir()
+        actors = [None, {"id": 1, "name": "Hero"}]
+        (dp / "Actors.json").write_text(json.dumps(actors), encoding="utf-8")
+        exists, _ = self.fn(dp, "villain")
+        assert exists is False
+
+
+# ── _skills_local_search_by_name ─────────────────────────────
+
+
+class TestSkillsLocalSearchByName:
+    fn = staticmethod(executor_module._skills_local_search_by_name)
+
+    def test_found(self, tmp_path: Path) -> None:
+        dp = tmp_path / "data"
+        dp.mkdir()
+        skills = [None, {"id": 1, "name": "Fire"}, {"id": 2, "name": "Ice"}]
+        (dp / "Skills.json").write_text(json.dumps(skills), encoding="utf-8")
+        exists, sid = self.fn(dp, "fire")
+        assert exists is True
+        assert sid == 1
+
+
+# ── _normalize_mcp_arguments ─────────────────────────────────
+
+
+class TestNormalizeMcpArguments:
+    fn = staticmethod(executor_module._normalize_mcp_arguments)
+
+    def test_actors_create_maps_actor_name(self) -> None:
+        result = self.fn("Actors.json", "create", {"actor_name": "Hero"})
+        assert result["name"] == "Hero"
+        assert "actor_name" not in result
+
+    def test_actors_search_sets_search_term(self) -> None:
+        result = self.fn("Actors.json", "search", {"actor_name": "Hero"})
+        assert result == {"searchTerm": "Hero"}
+
+    def test_actors_query_by_id(self) -> None:
+        result = self.fn("Actors.json", "query_by_id", {"actor_id": "3"})
+        assert result == {"actorId": 3}
+
+    def test_actors_update_actor(self) -> None:
+        result = self.fn(
+            "Actors.json", "update_actor",
+            {"actor_id": 1, "updates": {"maxLevel": 99}},
+        )
+        assert result == {"actorId": 1, "updates": {"maxLevel": 99}}
+
+    def test_skills_create_maps_skill_name(self) -> None:
+        result = self.fn("Skills.json", "create", {"skill_name": "Fire"})
+        assert result["name"] == "Fire"
+
+    def test_items_search_sets_search_term(self) -> None:
+        result = self.fn("Items.json", "search", {"item_name": "Potion"})
+        assert result == {"searchTerm": "Potion"}
+
+    def test_items_update_merges_fields(self) -> None:
+        result = self.fn(
+            "Items.json", "update",
+            {"item_id": 5, "new_description": "Good potion", "new_name": "Hi-Potion"},
+        )
+        assert result["itemId"] == 5
+        assert result["updates"]["description"] == "Good potion"
+        assert result["updates"]["name"] == "Hi-Potion"
+
+
+# ── _enrich_items_target_info_from_deps ──────────────────────
+
+
+class TestEnrichItemsTargetInfoFromDeps:
+    fn = staticmethod(executor_module._enrich_items_target_info_from_deps)
+
+    def test_inherits_item_id(self) -> None:
+        step = {"step_id": 2, "depends_on": [1]}
+        step_results = {1: {"item_id": 10, "exists": True}}
+        ti = {"name": "Potion"}
+        result = self.fn(step, step_results, ti)
+        assert result["item_id"] == 10
+
+    def test_skips_if_already_has_id(self) -> None:
+        step = {"step_id": 2, "depends_on": [1]}
+        step_results = {1: {"item_id": 99}}
+        ti = {"item_id": 5, "name": "Potion"}
+        result = self.fn(step, step_results, ti)
+        assert result["item_id"] == 5  # 원래 값 유지
+
+    def test_no_deps(self) -> None:
+        step = {"step_id": 1, "depends_on": []}
+        result = self.fn(step, {}, {"name": "X"})
+        assert "item_id" not in result

--- a/agent/tests/test_executor_mvp.py
+++ b/agent/tests/test_executor_mvp.py
@@ -104,7 +104,6 @@ async def test_executor_mvp():
 async def test_structured_execution_plan_actors(monkeypatch):
     """3단계 구조화 execution_plan: Actors.json query → 조건부 create."""
     executor_module = importlib.import_module("agent.graph.nodes.executor")
-    # MCP stdio는 테스트용 game_001과 파일 동기화가 어긋날 수 있어, 이 시나리오는 레거시 ActorManager로 고정 검증한다.
     monkeypatch.setattr(executor_module, "is_mcp_enabled", lambda: False)
 
     unique_name = f"ZZZ_EXECUTOR_STRUCT_TEST_{uuid.uuid4().hex[:8]}"
@@ -136,7 +135,6 @@ async def test_structured_execution_plan_actors(monkeypatch):
     result = await executor(state)
     logs = result.get("changes_log", [])
     assert len(logs) >= 2
-    # MCP가 꺼져있을 때의 이름과 켜져있을 때의 이름을 모두 찾도록 변경합니다.
     q = next(
         (x for x in logs if x.get("tool_name") in ("structured_actors_query", "get_actor")), None
     )
@@ -148,7 +146,8 @@ async def test_structured_execution_plan_actors(monkeypatch):
     assert q.get("exists") is False
     assert c is not None and c.get("success") is True
 
-    data_path = Path(__file__).resolve().parents[2] / "storage" / "games" / "game_001" / "data"
+    from app.backend.core.config import settings
+    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     mgr = ActorManager(data_path, "test_verify")
     verify = await mgr.execute("query", actor_name=unique_name)
     assert verify.get("exists") is True
@@ -168,11 +167,6 @@ async def test_structured_execution_plan_full_update_flow(monkeypatch):
     class_name = f"ZZZ_CLASS_{unique_suffix}"
     actor_name = f"ZZZ_ACTOR_{unique_suffix}"
 
-    # 4단계 엔진(Structured execution_plan)에서 아래 step들이 순서대로 실행돼야 한다.
-    # 1~2: Classes.json query -> create
-    # 3~4: Actors.json query -> create
-    # 5: Actors.json update(=classId 갱신)
-    # 6: System.json update(=partyMembers에 actorId 추가)
     state: AgentState = {
         "execution_plan": [
             {
@@ -247,7 +241,8 @@ async def test_structured_execution_plan_full_update_flow(monkeypatch):
         x.get("tool_name") == "structured_system_update" and x.get("success") is True for x in logs
     )
 
-    data_path = Path(__file__).resolve().parents[2] / "storage" / "games" / "game_001" / "data"
+    from app.backend.core.config import settings
+    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     class_mgr = ClassManager(data_path, "verify_class")
     actor_mgr = ActorManager(data_path, "verify_actor")
     system_mgr = SystemManager(data_path, "verify_system")
@@ -273,7 +268,8 @@ async def test_skill_manager_directly():
 
     print("\n🛠️ SkillManager 직접 테스트")
 
-    data_path = Path(__file__).resolve().parents[2] / "storage" / "games" / "game_001" / "data"
+    from app.backend.core.config import settings
+    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
 
     if not data_path.exists():
         print(f"❌ 데이터 경로 없음: {data_path}")
@@ -300,7 +296,8 @@ def check_game_files():
 
     print("\n📂 게임 파일 체크")
 
-    data_path = Path(__file__).resolve().parents[2] / "storage" / "games" / "game_001" / "data"
+    from app.backend.core.config import settings
+    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     required_files = ["Skills.json", "Enemies.json", "Items.json"]
 
     for file_name in required_files:
@@ -638,7 +635,8 @@ async def test_actors_update_class_inherits_actor_id_from_create(monkeypatch):
     assert logs[1].get("tool_name") == "structured_actors_update"
     assert logs[1].get("success") is True
 
-    data_path = Path(__file__).resolve().parents[2] / "storage" / "games" / "game_001" / "data"
+    from app.backend.core.config import settings
+    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     mgr = ActorManager(data_path, "verify_upd_cls")
     verify = await mgr.execute("query", actor_name=unique_name)
     assert verify.get("exists") is True
@@ -685,7 +683,8 @@ async def test_actors_update_rename_by_new_name_after_create(monkeypatch):
     assert logs[1].get("tool_name") == "structured_actors_update_general"
     assert logs[1].get("success") is True
 
-    data_path = Path(__file__).resolve().parents[2] / "storage" / "games" / "game_001" / "data"
+    from app.backend.core.config import settings
+    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     mgr = ActorManager(data_path, "verify_ren")
     assert (await mgr.execute("query", actor_name=old_name)).get("exists") is False
     assert (await mgr.execute("query", actor_name=new_name)).get("exists") is True
@@ -732,7 +731,8 @@ async def test_actors_rename_reconciles_wrong_planner_actor_id(monkeypatch):
     assert logs[1].get("tool_name") == "structured_actors_update_general"
     assert logs[1].get("success") is True
 
-    data_path = Path(__file__).resolve().parents[2] / "storage" / "games" / "game_001" / "data"
+    from app.backend.core.config import settings
+    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     mgr = ActorManager(data_path, "verify_rid")
     assert (await mgr.execute("query", actor_name=unique)).get("exists") is False
     assert (await mgr.execute("query", actor_name=new_name)).get("exists") is True
@@ -867,7 +867,6 @@ async def test_mcp_failure_fallback_policy_actors_create(monkeypatch):
     async def fake_call_mcp_tool(
         tool_name, arguments, data_path, path_arg_name="targetDir", mcp_server=None
     ):
-        # MCP가 실패하도록 강제: executor가 정책에 따라 레거시로 폴백하는지 확인한다.
         return {"success": False, "error": "simulated mcp failure"}
 
     monkeypatch.setattr(executor_module, "is_mcp_enabled", lambda: True)
@@ -898,13 +897,12 @@ async def test_mcp_failure_fallback_policy_actors_create(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_mcp_failure_abort_policy_system_update_game_title(monkeypatch):
-    """MCP 실패 시 레거시 분기가 없는 액션은 중단(Abort)되어야 한다."""
+    """MCP 실패 시 레거시 분기가 있는 System update_game_title은 폴백 성공해야 한다."""
     executor_module = importlib.import_module("agent.graph.nodes.executor")
 
     async def fake_call_mcp_tool(
         tool_name, arguments, data_path, path_arg_name="targetDir", mcp_server=None
     ):
-        # MCP 실패 강제: System의 update_game_title은 레거시 핸들러가 없으므로 abort로 떨어져야 한다.
         return {"success": False, "error": "simulated mcp failure"}
 
     monkeypatch.setattr(executor_module, "is_mcp_enabled", lambda: True)
@@ -930,8 +928,7 @@ async def test_mcp_failure_abort_policy_system_update_game_title(monkeypatch):
     result = await executor(state)
     log = result["changes_log"][0]
     assert log["tool_name"] == "structured_system_update_game_title"
-    assert log["success"] is True  # 이제 레거시 폴백으로 성공
-    # MCP 실패 후 레거시로 성공했으므로 MCP_ABORT_NO_FALLBACK 에러는 없음
+    assert log["success"] is True
 
 
 @pytest.mark.asyncio
@@ -1145,10 +1142,342 @@ def test_structured_create_item_sync_writes_items_json(tmp_path):
     assert arr[1]["effects"][0]["value2"] == 100
 
 
+# ──────────────────────────────────────────────────────────────
+# _structured_create_item_sync — 실패/엣지 케이스
+# ──────────────────────────────────────────────────────────────
+
+_VALID_ITEM_BASE: dict = {
+    "name": "포션",
+    "description": "테스트",
+    "iconIndex": 0,
+    "price": 100,
+    "itypeId": 1,
+    "consumable": True,
+    "scope": 7,
+    "occasion": 0,
+    "speed": 0,
+    "successRate": 100,
+    "repeats": 1,
+    "tpGain": 0,
+    "hitType": 0,
+    "animationId": -1,
+    "damage": {"type": 0, "elementId": 0, "formula": "0", "variance": 20, "critical": False},
+    "effects": [],
+    "note": "",
+}
+
+
+def _make_items_json(data_path: Path, arr: list | None = None):
+    """tmp_path 하위에 Items.json을 준비한다."""
+    import json as _json
+
+    data_path.mkdir(parents=True, exist_ok=True)
+    content = arr if arr is not None else [None, None]
+    (data_path / "Items.json").write_text(_json.dumps(content, ensure_ascii=False), encoding="utf-8")
+
+
+def test_create_item_sync_missing_id(tmp_path):
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_items_json(dp)
+    r = executor_module._structured_create_item_sync(dp, {"name": "포션"})
+    assert r["success"] is False
+    assert "item_id" in r["stderr"]
+
+
+def test_create_item_sync_invalid_id(tmp_path):
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_items_json(dp)
+    r = executor_module._structured_create_item_sync(dp, {"item_id": "xyz", "name": "포션"})
+    assert r["success"] is False
+    assert "xyz" in r["stderr"]
+
+
+def test_create_item_sync_no_file(tmp_path):
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    dp.mkdir(parents=True)
+    # Items.json 없음
+    r = executor_module._structured_create_item_sync(dp, {"item_id": 1, "name": "포션"})
+    assert r["success"] is False
+
+
+def test_create_item_sync_slot_conflict(tmp_path):
+    """슬롯에 이미 다른 이름의 아이템이 있으면 충돌 에러."""
+    import json as _json
+
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    existing_item = {**_VALID_ITEM_BASE, "id": 1, "name": "기존 포션"}
+    _make_items_json(dp, [None, existing_item])
+    r = executor_module._structured_create_item_sync(dp, {**_VALID_ITEM_BASE, "item_id": 1, "name": "새 포션"})
+    assert r["success"] is False
+    assert "기존 포션" in r["stderr"]
+
+
+def test_create_item_sync_schema_bad_scope(tmp_path):
+    """scope=99 (max 14) → Pydantic 검증 실패."""
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_items_json(dp)
+    info = {**_VALID_ITEM_BASE, "item_id": 1, "scope": 99}
+    r = executor_module._structured_create_item_sync(dp, info)
+    assert r["success"] is False
+    assert "스키마" in r["stderr"] or "scope" in r["stderr"].lower()
+
+
+def test_create_item_sync_default_damage(tmp_path):
+    """damage 키를 안 주면 기본 damage 블록이 적용된다."""
+    import json as _json
+
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_items_json(dp)
+    info = {k: v for k, v in _VALID_ITEM_BASE.items() if k != "damage"}
+    info["item_id"] = 1
+    r = executor_module._structured_create_item_sync(dp, info)
+    assert r["success"] is True
+    arr = _json.loads((dp / "Items.json").read_text(encoding="utf-8"))
+    assert "damage" in arr[1]
+    assert arr[1]["damage"]["formula"] == "0"
+
+
+def test_create_item_sync_effects_sanitized(tmp_path):
+    """code=11, value1=500, value2=0 → swap 적용 확인."""
+    import json as _json
+
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_items_json(dp)
+    info = {
+        **_VALID_ITEM_BASE,
+        "item_id": 1,
+        "effects": [{"code": 11, "dataId": 0, "value1": 500, "value2": 0}],
+    }
+    r = executor_module._structured_create_item_sync(dp, info)
+    assert r["success"] is True
+    arr = _json.loads((dp / "Items.json").read_text(encoding="utf-8"))
+    eff = arr[1]["effects"][0]
+    assert eff["value1"] == 0
+    assert eff["value2"] == 500
+
+
+def test_create_item_sync_skip_keys_filtered(tmp_path):
+    """query, searchTerm 등 skip 키는 저장 JSON에 포함되지 않는다."""
+    import json as _json
+
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_items_json(dp)
+    info = {
+        **_VALID_ITEM_BASE,
+        "item_id": 1,
+        "query": "포션 검색",
+        "searchTerm": "magic",
+        "item_name": "무시됨",
+    }
+    r = executor_module._structured_create_item_sync(dp, info)
+    assert r["success"] is True
+    arr = _json.loads((dp / "Items.json").read_text(encoding="utf-8"))
+    saved = arr[1]
+    assert "query" not in saved
+    assert "searchTerm" not in saved
+    assert "item_name" not in saved
+
+
+def test_create_item_sync_extends_array(tmp_path):
+    """item_id=5인데 배열 길이가 2면 null 패딩 후 기록."""
+    import json as _json
+
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_items_json(dp, [None, None])
+    info = {**_VALID_ITEM_BASE, "item_id": 5}
+    r = executor_module._structured_create_item_sync(dp, info)
+    assert r["success"] is True
+    arr = _json.loads((dp / "Items.json").read_text(encoding="utf-8"))
+    assert len(arr) >= 6
+    assert arr[5]["id"] == 5
+    # 중간 슬롯은 None
+    assert arr[2] is None
+    assert arr[3] is None
+    assert arr[4] is None
+
+
+def test_create_item_sync_corrupt_json(tmp_path):
+    """깨진 JSON 파일 → 읽기 실패."""
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    dp.mkdir(parents=True)
+    (dp / "Items.json").write_text("{{not json}}", encoding="utf-8")
+    r = executor_module._structured_create_item_sync(dp, {"item_id": 1, "name": "포션"})
+    assert r["success"] is False
+    assert "읽기 실패" in r["stderr"] or "Items.json" in r["stderr"]
+
+
+# ──────────────────────────────────────────────────────────────
+# _structured_create_enemy_sync — 성공/실패/엣지
+# ──────────────────────────────────────────────────────────────
+
+_VALID_ENEMY_BASE: dict = {
+    "name": "고블린",
+    "battlerName": "Goblin",
+    "battlerHue": 0,
+    "params": [100, 0, 10, 10, 10, 10, 10, 10],
+    "dropItems": [
+        {"kind": 0, "dataId": 1, "denominator": 1},
+        {"kind": 0, "dataId": 1, "denominator": 1},
+        {"kind": 0, "dataId": 1, "denominator": 1},
+    ],
+    "actions": [
+        {"skillId": 1, "rating": 5, "conditionType": 0, "conditionParam1": 0, "conditionParam2": 0}
+    ],
+    "traits": [],
+    "exp": 10,
+    "gold": 5,
+    "note": "",
+}
+
+
+def _make_enemies_json(data_path: Path, arr: list | None = None):
+    import json as _json
+
+    data_path.mkdir(parents=True, exist_ok=True)
+    content = arr if arr is not None else [None, None]
+    (data_path / "Enemies.json").write_text(
+        _json.dumps(content, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+# ── 성공 ──
+
+
+def test_create_enemy_sync_basic(tmp_path):
+    """유효한 enemy로 슬롯 기록 성공."""
+    import json as _json
+
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_enemies_json(dp)
+    info = {**_VALID_ENEMY_BASE, "enemy_id": 1}
+    r = executor_module._structured_create_enemy_sync(dp, info)
+    assert r["success"] is True
+    arr = _json.loads((dp / "Enemies.json").read_text(encoding="utf-8"))
+    assert arr[1]["name"] == "고블린"
+    assert arr[1]["id"] == 1
+    assert len(arr[1]["params"]) == 8
+
+
+def test_create_enemy_sync_extends_array(tmp_path):
+    """enemy_id=5, 배열 길이 2 → null 패딩 후 기록."""
+    import json as _json
+
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_enemies_json(dp, [None, None])
+    info = {**_VALID_ENEMY_BASE, "enemy_id": 5}
+    r = executor_module._structured_create_enemy_sync(dp, info)
+    assert r["success"] is True
+    arr = _json.loads((dp / "Enemies.json").read_text(encoding="utf-8"))
+    assert len(arr) >= 6
+    assert arr[5]["id"] == 5
+    assert arr[2] is None
+
+
+def test_create_enemy_sync_overwrites_same_name(tmp_path):
+    """같은 이름이면 슬롯 덮어쓰기 허용."""
+    import json as _json
+
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    existing = {**_VALID_ENEMY_BASE, "id": 1, "name": "고블린", "exp": 5}
+    _make_enemies_json(dp, [None, existing])
+    info = {**_VALID_ENEMY_BASE, "enemy_id": 1, "name": "고블린", "exp": 99}
+    r = executor_module._structured_create_enemy_sync(dp, info)
+    assert r["success"] is True
+    arr = _json.loads((dp / "Enemies.json").read_text(encoding="utf-8"))
+    assert arr[1]["exp"] == 99
+
+
+# ── 실패 ──
+
+
+def test_create_enemy_sync_missing_id(tmp_path):
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_enemies_json(dp)
+    r = executor_module._structured_create_enemy_sync(dp, {"name": "고블린"})
+    assert r["success"] is False
+    assert "enemy_id" in r["stderr"]
+
+
+def test_create_enemy_sync_invalid_id(tmp_path):
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_enemies_json(dp)
+    r = executor_module._structured_create_enemy_sync(dp, {"enemy_id": "abc"})
+    assert r["success"] is False
+    assert "abc" in r["stderr"]
+
+
+def test_create_enemy_sync_no_file(tmp_path):
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    dp.mkdir(parents=True)
+    r = executor_module._structured_create_enemy_sync(dp, {"enemy_id": 1})
+    assert r["success"] is False
+
+
+def test_create_enemy_sync_corrupt_json(tmp_path):
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    dp.mkdir(parents=True)
+    (dp / "Enemies.json").write_text("{{bad}}", encoding="utf-8")
+    r = executor_module._structured_create_enemy_sync(dp, {"enemy_id": 1})
+    assert r["success"] is False
+
+
+def test_create_enemy_sync_slot_conflict(tmp_path):
+    """슬롯에 다른 이름 적이 있으면 충돌 에러."""
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    existing = {**_VALID_ENEMY_BASE, "id": 1, "name": "고블린"}
+    _make_enemies_json(dp, [None, existing])
+    info = {**_VALID_ENEMY_BASE, "enemy_id": 1, "name": "드래곤"}
+    r = executor_module._structured_create_enemy_sync(dp, info)
+    assert r["success"] is False
+    assert "고블린" in r["stderr"]
+
+
+# ── 엣지 ──
+
+
+def test_create_enemy_sync_empty_array(tmp_path):
+    """빈 배열 → 에러."""
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_enemies_json(dp, [])
+    r = executor_module._structured_create_enemy_sync(dp, {"enemy_id": 1})
+    assert r["success"] is False
+    assert "비어 있지 않은 배열" in r["stderr"]
+
+
+def test_create_enemy_sync_params_validation_fail(tmp_path):
+    """params가 7개이면 스키마 검증 실패."""
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_enemies_json(dp)
+    info = {**_VALID_ENEMY_BASE, "enemy_id": 1, "params": [100, 0, 10, 10, 10, 10, 10]}
+    r = executor_module._structured_create_enemy_sync(dp, info)
+    assert r["success"] is False
+    assert "스키마" in r["stderr"] or "검증" in r["stderr"]
+
+
 if __name__ == "__main__":
     # 단독 실행시 테스트
     print("=" * 60)
-    print("🚀 Executor MVP 단독 테스트 실행")
+    print("Executor MVP 단독 테스트 실행")
     print("=" * 60)
 
     check_game_files()

--- a/agent/tests/test_executor_mvp.py
+++ b/agent/tests/test_executor_mvp.py
@@ -147,6 +147,7 @@ async def test_structured_execution_plan_actors(monkeypatch):
     assert c is not None and c.get("success") is True
 
     from app.backend.core.config import settings
+
     data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     mgr = ActorManager(data_path, "test_verify")
     verify = await mgr.execute("query", actor_name=unique_name)
@@ -242,6 +243,7 @@ async def test_structured_execution_plan_full_update_flow(monkeypatch):
     )
 
     from app.backend.core.config import settings
+
     data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     class_mgr = ClassManager(data_path, "verify_class")
     actor_mgr = ActorManager(data_path, "verify_actor")
@@ -269,6 +271,7 @@ async def test_skill_manager_directly():
     print("\n🛠️ SkillManager 직접 테스트")
 
     from app.backend.core.config import settings
+
     data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
 
     if not data_path.exists():
@@ -297,6 +300,7 @@ def check_game_files():
     print("\n📂 게임 파일 체크")
 
     from app.backend.core.config import settings
+
     data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     required_files = ["Skills.json", "Enemies.json", "Items.json"]
 
@@ -636,6 +640,7 @@ async def test_actors_update_class_inherits_actor_id_from_create(monkeypatch):
     assert logs[1].get("success") is True
 
     from app.backend.core.config import settings
+
     data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     mgr = ActorManager(data_path, "verify_upd_cls")
     verify = await mgr.execute("query", actor_name=unique_name)
@@ -684,6 +689,7 @@ async def test_actors_update_rename_by_new_name_after_create(monkeypatch):
     assert logs[1].get("success") is True
 
     from app.backend.core.config import settings
+
     data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     mgr = ActorManager(data_path, "verify_ren")
     assert (await mgr.execute("query", actor_name=old_name)).get("exists") is False
@@ -732,6 +738,7 @@ async def test_actors_rename_reconciles_wrong_planner_actor_id(monkeypatch):
     assert logs[1].get("success") is True
 
     from app.backend.core.config import settings
+
     data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
     mgr = ActorManager(data_path, "verify_rid")
     assert (await mgr.execute("query", actor_name=unique)).get("exists") is False
@@ -1173,7 +1180,9 @@ def _make_items_json(data_path: Path, arr: list | None = None):
 
     data_path.mkdir(parents=True, exist_ok=True)
     content = arr if arr is not None else [None, None]
-    (data_path / "Items.json").write_text(_json.dumps(content, ensure_ascii=False), encoding="utf-8")
+    (data_path / "Items.json").write_text(
+        _json.dumps(content, ensure_ascii=False), encoding="utf-8"
+    )
 
 
 def test_create_item_sync_missing_id(tmp_path):
@@ -1205,13 +1214,14 @@ def test_create_item_sync_no_file(tmp_path):
 
 def test_create_item_sync_slot_conflict(tmp_path):
     """슬롯에 이미 다른 이름의 아이템이 있으면 충돌 에러."""
-    import json as _json
 
     executor_module = importlib.import_module("agent.graph.nodes.executor")
     dp = tmp_path / "data"
     existing_item = {**_VALID_ITEM_BASE, "id": 1, "name": "기존 포션"}
     _make_items_json(dp, [None, existing_item])
-    r = executor_module._structured_create_item_sync(dp, {**_VALID_ITEM_BASE, "item_id": 1, "name": "새 포션"})
+    r = executor_module._structured_create_item_sync(
+        dp, {**_VALID_ITEM_BASE, "item_id": 1, "name": "새 포션"}
+    )
     assert r["success"] is False
     assert "기존 포션" in r["stderr"]
 

--- a/agent/tests/test_executor_mvp.py
+++ b/agent/tests/test_executor_mvp.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import importlib
+import json
 import logging
 import uuid
 from pathlib import Path
@@ -23,6 +24,115 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+_TEST_GAME_ID = f"game_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture(autouse=True)
+def _ensure_test_game_data():
+    """STORAGE_PATH/{_TEST_GAME_ID}/data/ 에 최소 JSON 생성."""
+    from app.backend.core.config import settings
+
+    data_path = Path(settings.STORAGE_PATH) / _TEST_GAME_ID / "data"
+    if (data_path / "Actors.json").exists():
+        return
+
+    data_path.mkdir(parents=True, exist_ok=True)
+
+    _base_system = {
+        "gameTitle": "테스트 게임",
+        "versionId": 1,
+        "locale": "ko_KR",
+        "startMapId": 1,
+        "startX": 5,
+        "startY": 5,
+        "variables": [""] * 100,
+        "switches": [""] * 100,
+        "currencyUnit": "G",
+        "windowTone": [0, 0, 0, 0],
+        "battleBgm": {"name": "", "pan": 0, "pitch": 100, "volume": 90},
+        "battleback1Name": "",
+        "battleback2Name": "",
+        "partyMembers": [1],
+        "testBattlers": [],
+        "terms": {"basic": [], "commands": [], "params": [], "messages": {}},
+    }
+    _base_actors = [
+        None,
+        {
+            "id": 1,
+            "name": "용사",
+            "nickname": "",
+            "classId": 1,
+            "initialLevel": 1,
+            "maxLevel": 99,
+            "characterName": "Actor1",
+            "characterIndex": 0,
+            "faceName": "Actor1",
+            "faceIndex": 0,
+            "battlerName": "Actor1_1",
+            "equips": [0, 0, 0, 0, 0],
+            "traits": [],
+            "note": "",
+            "profile": "",
+        },
+        {
+            "id": 2,
+            "name": "리드",
+            "nickname": "",
+            "classId": 1,
+            "initialLevel": 1,
+            "maxLevel": 99,
+            "characterName": "Actor1",
+            "characterIndex": 1,
+            "faceName": "Actor1",
+            "faceIndex": 1,
+            "battlerName": "Actor1_2",
+            "equips": [0, 0, 0, 0, 0],
+            "traits": [],
+            "note": "",
+            "profile": "",
+        },
+    ]
+    _base_classes = [
+        None,
+        {
+            "id": 1,
+            "name": "전사",
+            "expParams": [30, 20, 30, 30],
+            "params": [[0] * 99] * 8,
+            "learnings": [],
+            "traits": [],
+            "note": "",
+        },
+    ]
+    _base_skills = [
+        None,
+        {
+            "id": 1,
+            "name": "공격",
+            "description": "",
+            "iconIndex": 76,
+            "mpCost": 0,
+            "scope": 1,
+            "occasion": 1,
+            "damage": {"type": 1, "elementId": -1, "formula": "a.atk * 4 - b.def * 2"},
+            "effects": [],
+            "note": "",
+        },
+    ]
+    _base_items = [None]
+
+    for fname, data in [
+        ("System.json", _base_system),
+        ("Actors.json", _base_actors),
+        ("Classes.json", _base_classes),
+        ("Skills.json", _base_skills),
+        ("Items.json", _base_items),
+        ("Enemies.json", [None]),
+    ]:
+        (data_path / fname).write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+
 @pytest.mark.integration
 async def test_executor_mvp():
     """MVP 기본 동작 테스트"""
@@ -34,7 +144,7 @@ async def test_executor_mvp():
         "execution_plan": [
             {"task": "파이어볼 스킬 추가해줘", "description": "새로운 화염 공격 스킬"}
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -61,7 +171,7 @@ async def test_executor_mvp():
     # ── 테스트 2: 레벨 설정 ──────────────────────────────────
     test_state2 = {
         "execution_plan": [{"task": "주인공 레벨 50으로 설정해줘"}],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -82,7 +192,7 @@ async def test_executor_mvp():
     # ── 테스트 3: 재시도 로직 ────────────────────────────────
     test_state3 = {
         "execution_plan": [{"task": "유효하지 않은 명령"}],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 3,  # 최대치 초과
     }
 
@@ -129,7 +239,7 @@ async def test_structured_execution_plan_actors(monkeypatch):
                 "condition": "step 1에서 캐릭터가 존재하지 않을 경우",
             },
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -149,7 +259,7 @@ async def test_structured_execution_plan_actors(monkeypatch):
 
     from app.backend.core.config import settings
 
-    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
+    data_path = Path(settings.STORAGE_PATH) / _TEST_GAME_ID / "data"
     mgr = ActorManager(data_path, "test_verify")
     verify = await mgr.execute("query", actor_name=unique_name)
     assert verify.get("exists") is True
@@ -226,7 +336,7 @@ async def test_structured_execution_plan_full_update_flow(monkeypatch):
                 "condition": "",
             },
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -245,7 +355,7 @@ async def test_structured_execution_plan_full_update_flow(monkeypatch):
 
     from app.backend.core.config import settings
 
-    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
+    data_path = Path(settings.STORAGE_PATH) / _TEST_GAME_ID / "data"
     class_mgr = ClassManager(data_path, "verify_class")
     actor_mgr = ActorManager(data_path, "verify_actor")
     system_mgr = SystemManager(data_path, "verify_system")
@@ -273,7 +383,7 @@ async def test_skill_manager_directly():
 
     from app.backend.core.config import settings
 
-    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
+    data_path = Path(settings.STORAGE_PATH) / _TEST_GAME_ID / "data"
 
     if not data_path.exists():
         print(f"❌ 데이터 경로 없음: {data_path}")
@@ -302,7 +412,7 @@ def check_game_files():
 
     from app.backend.core.config import settings
 
-    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
+    data_path = Path(settings.STORAGE_PATH) / _TEST_GAME_ID / "data"
     required_files = ["Skills.json", "Enemies.json", "Items.json"]
 
     for file_name in required_files:
@@ -348,7 +458,7 @@ async def test_structured_mcp_alias_actor_update_routes_update_actor(monkeypatch
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -389,7 +499,7 @@ async def test_structured_mcp_actor_update_merges_top_level_max_level(monkeypatc
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -428,7 +538,7 @@ async def test_structured_mcp_actor_update_snake_case_maps_to_schema(monkeypatch
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -469,7 +579,7 @@ async def test_structured_mcp_alias_system_update_game_title(monkeypatch):
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -510,7 +620,7 @@ async def test_structured_mcp_alias_system_update_starting_position(monkeypatch)
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -540,7 +650,7 @@ async def test_actors_query_by_id_legacy_when_mcp_off(monkeypatch):
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -570,7 +680,7 @@ async def test_actors_list_search_legacy_when_mcp_off(monkeypatch):
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
     result_list = await executor(state_list)
@@ -591,7 +701,7 @@ async def test_actors_list_search_legacy_when_mcp_off(monkeypatch):
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
     result_search = await executor(state_search)
@@ -629,7 +739,7 @@ async def test_actors_update_class_inherits_actor_id_from_create(monkeypatch):
                 "condition": "",
             },
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
     result = await executor(state)
@@ -642,7 +752,7 @@ async def test_actors_update_class_inherits_actor_id_from_create(monkeypatch):
 
     from app.backend.core.config import settings
 
-    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
+    data_path = Path(settings.STORAGE_PATH) / _TEST_GAME_ID / "data"
     mgr = ActorManager(data_path, "verify_upd_cls")
     verify = await mgr.execute("query", actor_name=unique_name)
     assert verify.get("exists") is True
@@ -681,7 +791,7 @@ async def test_actors_update_rename_by_new_name_after_create(monkeypatch):
                 "condition": "",
             },
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
     result = await executor(state)
@@ -691,7 +801,7 @@ async def test_actors_update_rename_by_new_name_after_create(monkeypatch):
 
     from app.backend.core.config import settings
 
-    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
+    data_path = Path(settings.STORAGE_PATH) / _TEST_GAME_ID / "data"
     mgr = ActorManager(data_path, "verify_ren")
     assert (await mgr.execute("query", actor_name=old_name)).get("exists") is False
     assert (await mgr.execute("query", actor_name=new_name)).get("exists") is True
@@ -730,7 +840,7 @@ async def test_actors_rename_reconciles_wrong_planner_actor_id(monkeypatch):
                 "condition": "",
             },
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
     result = await executor(state)
@@ -740,7 +850,7 @@ async def test_actors_rename_reconciles_wrong_planner_actor_id(monkeypatch):
 
     from app.backend.core.config import settings
 
-    data_path = Path(settings.STORAGE_PATH) / "game_001" / "data"
+    data_path = Path(settings.STORAGE_PATH) / _TEST_GAME_ID / "data"
     mgr = ActorManager(data_path, "verify_rid")
     assert (await mgr.execute("query", actor_name=unique)).get("exists") is False
     assert (await mgr.execute("query", actor_name=new_name)).get("exists") is True
@@ -775,7 +885,7 @@ async def test_structured_mcp_alias_actor_query_by_id(monkeypatch):
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -815,7 +925,7 @@ async def test_structured_mcp_alias_system_update_set_variable_name(monkeypatch)
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -855,7 +965,7 @@ async def test_structured_mcp_alias_system_update_set_switch_name(monkeypatch):
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -893,7 +1003,7 @@ async def test_mcp_failure_fallback_policy_actors_create(monkeypatch):
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -929,7 +1039,7 @@ async def test_mcp_failure_abort_policy_system_update_game_title(monkeypatch):
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -967,7 +1077,7 @@ async def test_items_query_normalizes_to_search_for_planner(monkeypatch):
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -995,7 +1105,7 @@ async def test_unsupported_structured_step_error_is_standardized():
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
@@ -1031,13 +1141,13 @@ async def test_executor_returns_modified_file_paths_for_reported_changes(monkeyp
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 
     result = await executor(state)
 
-    expected_path = str(executor_module._get_data_path("game_001") / "Actors.json")
+    expected_path = str(executor_module._get_data_path(_TEST_GAME_ID) / "Actors.json")
     assert result["modified_file_paths"] == [expected_path]
 
 
@@ -1066,7 +1176,7 @@ async def test_executor_returns_empty_modified_file_paths_for_read_only_query(mo
                 "condition": "",
             }
         ],
-        "game_id": "game_001",
+        "game_id": _TEST_GAME_ID,
         "retry_count": 0,
     }
 

--- a/agent/tests/test_executor_mvp.py
+++ b/agent/tests/test_executor_mvp.py
@@ -23,6 +23,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.integration
 async def test_executor_mvp():
     """MVP 기본 동작 테스트"""
 

--- a/agent/tests/test_game_data_io.py
+++ b/agent/tests/test_game_data_io.py
@@ -1,0 +1,209 @@
+"""game_data_io 순수 로직 테스트.
+
+STORAGE_PATH를 monkeypatch로 tmp_path에 연결해서
+실제 외부 서비스 없이 JSON 읽기/쓰기/스트리밍을 검증한다.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def game_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """tmp_path 기반 game_001/data/ 구조를 만들고 STORAGE_PATH를 패치."""
+    import agent.utils.game_data_io as mod
+
+    storage = tmp_path / "storage" / "games"
+    data = storage / "game_001" / "data"
+    data.mkdir(parents=True)
+    monkeypatch.setattr(mod, "STORAGE_PATH", str(storage))
+    return data
+
+
+# ── read_game_json ───────────────────────────────────────────
+
+
+class TestReadGameJson:
+    def test_read_normal(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import read_game_json
+
+        (game_dir / "Actors.json").write_text(
+            json.dumps([None, {"id": 1, "name": "Hero"}]), encoding="utf-8"
+        )
+        result = read_game_json("game_001", "Actors.json")
+        assert result[1]["name"] == "Hero"
+
+    def test_read_category_name(self, game_dir: Path) -> None:
+        """카테고리명 'actor'로 호출 시 Actors.json을 읽는다."""
+        from agent.utils.game_data_io import read_game_json
+
+        (game_dir / "Actors.json").write_text(json.dumps([None]), encoding="utf-8")
+        result = read_game_json("game_001", "actor")
+        assert result == [None]
+
+    def test_read_file_not_found(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import read_game_json
+
+        result = read_game_json("game_001", "Missing.json")
+        assert result is None
+
+    def test_read_corrupt_json(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import read_game_json
+
+        (game_dir / "Bad.json").write_text("{{not json}}", encoding="utf-8")
+        result = read_game_json("game_001", "Bad.json")
+        assert result is None
+
+    def test_read_unknown_category_appends_json(self, game_dir: Path) -> None:
+        """CATEGORY_TO_PLURAL에 없는 이름은 그대로 .json을 붙인다."""
+        from agent.utils.game_data_io import read_game_json
+
+        (game_dir / "Custom.json").write_text(json.dumps({"key": "val"}), encoding="utf-8")
+        result = read_game_json("game_001", "Custom")
+        assert result == {"key": "val"}
+
+
+# ── write_game_json ──────────────────────────────────────────
+
+
+class TestWriteGameJson:
+    def test_write_normal(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import write_game_json
+
+        data = [None, {"id": 1, "name": "Sword"}]
+        assert write_game_json("game_001", "Items.json", data) is True
+        written = json.loads((game_dir / "Items.json").read_text(encoding="utf-8"))
+        assert written[1]["name"] == "Sword"
+
+    def test_write_category_name(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import write_game_json
+
+        assert write_game_json("game_001", "item", [None]) is True
+        assert (game_dir / "Items.json").exists()
+
+    def test_write_creates_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """data 디렉터리가 없으면 자동 생성."""
+        import agent.utils.game_data_io as mod
+
+        storage = tmp_path / "new_storage"
+        monkeypatch.setattr(mod, "STORAGE_PATH", str(storage))
+        from agent.utils.game_data_io import write_game_json
+
+        assert write_game_json("game_999", "Test.json", {"ok": True}) is True
+
+
+# ── read_game_json_fields ────────────────────────────────────
+
+
+class TestReadGameJsonFields:
+    def test_extract_fields(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import read_game_json_fields
+
+        actors = [None, {"id": 1, "name": "Hero", "classId": 1, "extra": "big"}]
+        (game_dir / "Actors.json").write_text(json.dumps(actors), encoding="utf-8")
+        result = read_game_json_fields("game_001", "Actors", ["name"])
+        assert result[0] is None
+        assert result[1]["name"] == "Hero"
+        assert result[1]["id"] == 1  # id는 자동 포함
+        assert "extra" not in result[1]
+
+    def test_file_not_found(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import read_game_json_fields
+
+        assert read_game_json_fields("game_001", "Missing", ["name"]) == []
+
+
+# ── get_next_append_id_streaming ─────────────────────────────
+
+
+class TestGetNextAppendIdStreaming:
+    def test_normal_array(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import get_next_append_id_streaming
+
+        (game_dir / "Items.json").write_text(json.dumps([None, {"id": 1}]), encoding="utf-8")
+        assert get_next_append_id_streaming(str(game_dir / "Items.json")) == 2
+
+    def test_file_not_found(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import get_next_append_id_streaming
+
+        assert get_next_append_id_streaming(str(game_dir / "Missing.json")) == 1
+
+
+# ── get_next_empty_slot_id_streaming ─────────────────────────
+
+
+class TestGetNextEmptySlotIdStreaming:
+    def test_finds_empty_name(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import get_next_empty_slot_id_streaming
+
+        data = [None, {"id": 1, "name": "Used"}, {"id": 2, "name": ""}, {"id": 3, "name": "Also"}]
+        (game_dir / "Actors.json").write_text(json.dumps(data), encoding="utf-8")
+        assert get_next_empty_slot_id_streaming(str(game_dir / "Actors.json")) == 2
+
+    def test_no_empty_slot_returns_append(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import get_next_empty_slot_id_streaming
+
+        data = [None, {"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
+        (game_dir / "Actors.json").write_text(json.dumps(data), encoding="utf-8")
+        assert get_next_empty_slot_id_streaming(str(game_dir / "Actors.json")) == 3
+
+    def test_file_not_found(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import get_next_empty_slot_id_streaming
+
+        assert get_next_empty_slot_id_streaming(str(game_dir / "Missing.json")) == 1
+
+
+# ── get_next_entity_id ───────────────────────────────────────
+
+
+class TestGetNextEntityId:
+    def test_fill_gaps_strategy(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import get_next_entity_id
+
+        data = [None, {"id": 1, "name": "A"}, {"id": 2, "name": ""}]
+        (game_dir / "Actors.json").write_text(json.dumps(data), encoding="utf-8")
+        assert get_next_entity_id("game_001", "actor", strategy="fill_gaps") == 2
+
+    def test_append_strategy(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import get_next_entity_id
+
+        data = [None, {"id": 1, "name": "A"}]
+        (game_dir / "Actors.json").write_text(json.dumps(data), encoding="utf-8")
+        assert get_next_entity_id("game_001", "actor", strategy="append") == 2
+
+
+# ── get_system_context ───────────────────────────────────────
+
+
+class TestGetSystemContext:
+    def test_full_context(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import get_system_context
+
+        system = {
+            "gameTitle": "My RPG",
+            "currencyUnit": "Gold",
+            "elements": ["", "Fire"],
+            "startMapId": 2,
+            "startX": 5,
+            "startY": 10,
+            "partyMembers": [1],
+        }
+        actors = [None, {"id": 1, "name": "Hero"}]
+        (game_dir / "System.json").write_text(json.dumps(system), encoding="utf-8")
+        (game_dir / "Actors.json").write_text(json.dumps(actors), encoding="utf-8")
+
+        ctx = get_system_context("game_001")
+        assert ctx["gameTitle"] == "My RPG"
+        assert ctx["hero"]["name"] == "Hero"
+        assert ctx["startPosition"]["mapId"] == 2
+
+    def test_missing_files(self, game_dir: Path) -> None:
+        from agent.utils.game_data_io import get_system_context
+
+        ctx = get_system_context("game_001")
+        assert ctx["gameTitle"] == "알 수 없음"
+        assert ctx["hero"]["name"] == "알 수 없음"

--- a/agent/tests/test_game_paths.py
+++ b/agent/tests/test_game_paths.py
@@ -1,0 +1,102 @@
+"""game_paths.ensure_rpgmaker_mz_project_shell 테스트.
+
+tmp_path에 base_game과 game_root를 만들어 테스트.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def base_and_game(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """base_game과 game_root를 tmp_path에 구성."""
+    from app.backend.core.config import settings
+
+    base = tmp_path / "base_game"
+    base.mkdir()
+    (base / "game.rmmzproject").write_text("{}", encoding="utf-8")
+    (base / "package.json").write_text("{}", encoding="utf-8")
+    (base / "index.html").write_text("<html/>", encoding="utf-8")
+    css = base / "css"
+    css.mkdir()
+    (css / "main.css").write_text("body{}", encoding="utf-8")
+    js = base / "js"
+    js.mkdir()
+    (js / "main.js").write_text("//js", encoding="utf-8")
+
+    game_root = tmp_path / "game_001"
+    game_root.mkdir()
+    (game_root / "data").mkdir()
+
+    monkeypatch.setattr(settings, "BASE_GAME_PATH", str(base))
+
+    return base, game_root
+
+
+class TestEnsureRpgmakerMzProjectShell:
+    def test_copies_root_files(self, base_and_game) -> None:
+        from app.backend.core.game_paths import ensure_rpgmaker_mz_project_shell
+
+        _, game_root = base_and_game
+        ensure_rpgmaker_mz_project_shell(game_root)
+
+        assert (game_root / "game.rmmzproject").exists()
+        assert (game_root / "package.json").exists()
+        assert (game_root / "index.html").exists()
+
+    def test_copies_css_dir(self, base_and_game) -> None:
+        from app.backend.core.game_paths import ensure_rpgmaker_mz_project_shell
+
+        _, game_root = base_and_game
+        ensure_rpgmaker_mz_project_shell(game_root)
+
+        assert (game_root / "css" / "main.css").exists()
+
+    def test_symlinks_js_posix(self, base_and_game) -> None:
+        from app.backend.core.game_paths import ensure_rpgmaker_mz_project_shell
+
+        _, game_root = base_and_game
+        ensure_rpgmaker_mz_project_shell(game_root)
+
+        js_dst = game_root / "js"
+        if os.name == "posix":
+            assert js_dst.is_symlink()
+            assert (js_dst / "main.js").exists()
+        else:
+            # Windows: 심볼릭 링크 없이 생략
+            pass
+
+    def test_skips_existing(self, base_and_game) -> None:
+        from app.backend.core.game_paths import ensure_rpgmaker_mz_project_shell
+
+        _, game_root = base_and_game
+        # 미리 파일 생성
+        (game_root / "game.rmmzproject").write_text("existing", encoding="utf-8")
+
+        ensure_rpgmaker_mz_project_shell(game_root)
+
+        # 기존 파일이 덮어쓰이지 않음
+        assert (game_root / "game.rmmzproject").read_text() == "existing"
+
+    def test_missing_base_is_noop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.backend.core.config import settings
+        from app.backend.core.game_paths import ensure_rpgmaker_mz_project_shell
+
+        monkeypatch.setattr(settings, "BASE_GAME_PATH", str(tmp_path / "nonexistent"))
+        game_root = tmp_path / "game"
+        game_root.mkdir()
+
+        # 에러 없이 종료
+        ensure_rpgmaker_mz_project_shell(game_root)
+
+    def test_missing_game_root_is_noop(self, base_and_game) -> None:
+        from app.backend.core.game_paths import ensure_rpgmaker_mz_project_shell
+
+        _, _ = base_and_game
+        nonexistent = Path("/tmp/nonexistent_game_root_xyz")
+        # 에러 없이 종료
+        ensure_rpgmaker_mz_project_shell(nonexistent)

--- a/agent/tests/test_managers.py
+++ b/agent/tests/test_managers.py
@@ -1,11 +1,11 @@
 """Manager 단위 테스트 — SystemManager, ClassManager, ActorManager, SkillManager.
 
-로컬 game_001/data/ 의 실제 JSON을 사용한다.
-테스트에서 생성한 데이터는 고유 이름(ZZZ_ prefix)으로 충돌을 방지한다.
+tmp_path에 최소 fixture 데이터를 생성하여 외부 파일 의존 없이 테스트한다.
 """
 
 from __future__ import annotations
 
+import json
 import uuid
 from pathlib import Path
 
@@ -16,11 +16,92 @@ from app.backend.services.json_modify_tools.managers.class_manager import ClassM
 from app.backend.services.json_modify_tools.managers.skill_manager import SkillManager
 from app.backend.services.json_modify_tools.managers.system_manager import SystemManager
 
+# ── fixture 데이터 ──────────────────────────────────────────────
 
-def _get_data_path() -> Path:
-    from app.backend.core.config import settings
 
-    return Path(settings.STORAGE_PATH) / "game_001" / "data"
+def _write_json(path: Path, data) -> None:
+    path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+
+@pytest.fixture()
+def data_path(tmp_path: Path) -> Path:
+    """최소 RPG Maker MZ JSON 파일들을 tmp_path에 생성."""
+    # System.json
+    _write_json(
+        tmp_path / "System.json",
+        {
+            "gameTitle": "테스트 게임",
+            "startMapId": 1,
+            "startX": 5,
+            "startY": 5,
+            "variables": [""] * 20,
+            "switches": [""] * 20,
+        },
+    )
+
+    # Classes.json
+    _write_json(
+        tmp_path / "Classes.json",
+        [
+            None,
+            {
+                "id": 1,
+                "name": "전사",
+                "expParams": [30, 20, 30, 30],
+                "params": [[0] * 99] * 8,
+                "learnings": [],
+                "traits": [],
+                "note": "",
+            },
+        ],
+    )
+
+    # Actors.json
+    _write_json(
+        tmp_path / "Actors.json",
+        [
+            None,
+            {
+                "id": 1,
+                "name": "용사",
+                "nickname": "",
+                "classId": 1,
+                "initialLevel": 1,
+                "maxLevel": 99,
+                "characterName": "Actor1",
+                "characterIndex": 0,
+                "faceName": "Actor1",
+                "faceIndex": 0,
+                "battlerName": "Actor1_1",
+                "equips": [0, 0, 0, 0, 0],
+                "traits": [],
+                "note": "",
+                "profile": "",
+            },
+        ],
+    )
+
+    # Skills.json
+    _write_json(
+        tmp_path / "Skills.json",
+        [
+            None,
+            {
+                "id": 1,
+                "name": "공격",
+                "description": "",
+                "iconIndex": 76,
+                "mpCost": 0,
+                "scope": 1,
+                "occasion": 1,
+                "damage": {"type": 1, "elementId": -1, "formula": "a.atk * 4 - b.def * 2"},
+                "effects": [],
+                "note": "",
+            },
+        ],
+    )
+
+    return tmp_path
 
 
 # ── SystemManager ────────────────────────────────────────────
@@ -28,23 +109,17 @@ def _get_data_path() -> Path:
 
 class TestSystemManager:
     @pytest.fixture(autouse=True)
-    def _setup(self):
-        self.mgr = SystemManager(_get_data_path(), "test_sys")
+    def _setup(self, data_path: Path):
+        self.mgr = SystemManager(data_path, "test_sys")
 
     @pytest.mark.asyncio
     async def test_update_game_title(self) -> None:
-        old_data = self.mgr.load_json_data()
-        old_title = old_data.get("gameTitle", "")
-
-        r = await self.mgr.execute(
-            "update_game_title", target_info={"game_title": "TEST_TITLE_TMP"}
-        )
+        r = await self.mgr.execute("update_game_title", target_info={"game_title": "NEW_TITLE"})
         assert r["success"] is True
-        assert r["old_title"] == old_title
-        assert r["new_title"] == "TEST_TITLE_TMP"
+        assert r["new_title"] == "NEW_TITLE"
 
-        # 복원
-        await self.mgr.execute("update_game_title", target_info={"game_title": old_title})
+        data = self.mgr.load_json_data()
+        assert data["gameTitle"] == "NEW_TITLE"
 
     @pytest.mark.asyncio
     async def test_update_game_title_empty(self) -> None:
@@ -59,9 +134,6 @@ class TestSystemManager:
         assert r["success"] is True
         system = self.mgr.load_json_data()
         assert system["variables"][5] == "test_var"
-
-        # 복원
-        await self.mgr.execute("set_variable_name", target_info={"variable_id": 5, "name": ""})
 
     @pytest.mark.asyncio
     async def test_set_variable_name_invalid_id(self) -> None:
@@ -79,32 +151,17 @@ class TestSystemManager:
         system = self.mgr.load_json_data()
         assert system["switches"][3] == "test_switch"
 
-        # 복원
-        await self.mgr.execute("set_switch_name", target_info={"switch_id": 3, "name": ""})
-
     @pytest.mark.asyncio
     async def test_update_starting_position(self) -> None:
-        old = self.mgr.load_json_data()
-        old_map = old.get("startMapId")
-        old_x = old.get("startX")
-        old_y = old.get("startY")
-
         r = await self.mgr.execute(
             "update_starting_position",
             target_info={"map_id": 2, "x": 10, "y": 20},
         )
         assert r["success"] is True
-
         system = self.mgr.load_json_data()
         assert system["startMapId"] == 2
         assert system["startX"] == 10
         assert system["startY"] == 20
-
-        # 복원
-        await self.mgr.execute(
-            "update_starting_position",
-            target_info={"map_id": old_map, "x": old_x, "y": old_y},
-        )
 
     @pytest.mark.asyncio
     async def test_unsupported_action(self) -> None:
@@ -117,27 +174,17 @@ class TestSystemManager:
 
 class TestClassManager:
     @pytest.fixture(autouse=True)
-    def _setup(self):
-        self.mgr = ClassManager(_get_data_path(), "test_cls")
+    def _setup(self, data_path: Path):
+        self.mgr = ClassManager(data_path, "test_cls")
 
     @pytest.mark.asyncio
     async def test_query_existing(self) -> None:
-        """기본 데이터에 있는 클래스를 조회."""
-        data = self.mgr.load_json_data()
-        # 첫 번째 실제 클래스 이름 찾기
-        first_name = None
-        for item in data:
-            if isinstance(item, dict) and item.get("name"):
-                first_name = item["name"]
-                break
-        assert first_name is not None
-
-        r = await self.mgr.execute("query", class_name=first_name)
+        r = await self.mgr.execute("query", class_name="전사")
         assert r.get("exists") is True
 
     @pytest.mark.asyncio
     async def test_query_not_found(self) -> None:
-        r = await self.mgr.execute("query", class_name="ZZZ_NONEXISTENT_CLASS")
+        r = await self.mgr.execute("query", class_name="ZZZ_NONEXISTENT")
         assert r.get("exists") is False
 
     @pytest.mark.asyncio
@@ -155,26 +202,17 @@ class TestClassManager:
 
 class TestActorManager:
     @pytest.fixture(autouse=True)
-    def _setup(self):
-        self.mgr = ActorManager(_get_data_path(), "test_actor")
+    def _setup(self, data_path: Path):
+        self.mgr = ActorManager(data_path, "test_actor")
 
     @pytest.mark.asyncio
     async def test_query_existing_by_name(self) -> None:
-        """기본 데이터에 있는 액터를 이름으로 조회."""
-        data = self.mgr.load_json_data()
-        first_name = None
-        for item in data:
-            if isinstance(item, dict) and item.get("name"):
-                first_name = item["name"]
-                break
-        assert first_name is not None
-
-        r = await self.mgr.execute("query", actor_name=first_name)
+        r = await self.mgr.execute("query", actor_name="용사")
         assert r.get("exists") is True
 
     @pytest.mark.asyncio
     async def test_query_not_found(self) -> None:
-        r = await self.mgr.execute("query", actor_name="ZZZ_NONEXISTENT_ACTOR")
+        r = await self.mgr.execute("query", actor_name="ZZZ_NONEXISTENT")
         assert r.get("exists") is False
 
     @pytest.mark.asyncio
@@ -185,22 +223,12 @@ class TestActorManager:
 
     @pytest.mark.asyncio
     async def test_search_actor(self) -> None:
-        """기본 데이터의 첫 액터 이름으로 검색."""
-        data = self.mgr.load_json_data()
-        first_name = None
-        for item in data:
-            if isinstance(item, dict) and item.get("name"):
-                first_name = item["name"]
-                break
-        assert first_name is not None
-
-        r = await self.mgr.execute("search", target_info={"searchTerm": first_name})
+        r = await self.mgr.execute("search", target_info={"searchTerm": "용사"})
         assert r.get("success") is True
         assert r.get("exists") is True
 
     @pytest.mark.asyncio
     async def test_update_general(self) -> None:
-        """create → update_general → 복원."""
         unique = f"ZZZ_UPD_{uuid.uuid4().hex[:8]}"
         cr = await self.mgr.execute("create", actor_name=unique)
         assert cr.get("success") is True
@@ -217,14 +245,12 @@ class TestActorManager:
         assert "nickname" in r.get("updated_fields", [])
         assert "initialLevel" in r.get("updated_fields", [])
 
-        # 값 확인
         data = self.mgr.load_json_data()
         assert data[actor_id]["nickname"] == "테스트닉"
         assert data[actor_id]["initialLevel"] == 10
 
     @pytest.mark.asyncio
     async def test_update_general_type_coercion(self) -> None:
-        """문자열 '10' → int 10 변환."""
         unique = f"ZZZ_COERCE_{uuid.uuid4().hex[:8]}"
         cr = await self.mgr.execute("create", actor_name=unique)
         actor_id = cr.get("actor_id")
@@ -234,7 +260,6 @@ class TestActorManager:
             target_info={"actor_id": actor_id, "updates": {"initialLevel": "15"}},
         )
         assert r.get("success") is True
-
         data = self.mgr.load_json_data()
         assert data[actor_id]["initialLevel"] == 15
         assert isinstance(data[actor_id]["initialLevel"], int)
@@ -249,7 +274,6 @@ class TestActorManager:
 
     @pytest.mark.asyncio
     async def test_update_general_no_valid_fields(self) -> None:
-        """지원하지 않는 필드만 주면 실패."""
         unique = f"ZZZ_NOFLD_{uuid.uuid4().hex[:8]}"
         cr = await self.mgr.execute("create", actor_name=unique)
         actor_id = cr.get("actor_id")
@@ -262,25 +286,16 @@ class TestActorManager:
 
     @pytest.mark.asyncio
     async def test_query_empty_name_fails(self) -> None:
-        """빈 actor_name은 에러."""
         r = await self.mgr.execute("query", actor_name="")
         assert r.get("success") is False
 
     @pytest.mark.asyncio
     async def test_query_by_id_out_of_range(self) -> None:
-        """범위 밖 actor_id — actor_name으로 검색하면 exists=False."""
         r = await self.mgr.execute("query", actor_name="ZZZ_NEVER_EXISTS_99999")
         assert r.get("exists") is False
 
     @pytest.mark.asyncio
     async def test_update_general_bulk(self) -> None:
-        """전체 액터에 일괄 필드 업데이트."""
-        data = self.mgr.load_json_data()
-        originals = {}
-        for i, a in enumerate(data):
-            if isinstance(a, dict):
-                originals[i] = a.get("initialLevel")
-
         r = await self.mgr.execute(
             "update_general_bulk",
             target_info={
@@ -291,12 +306,10 @@ class TestActorManager:
         assert r.get("success") is True
         assert r.get("updated_count", 0) > 0
 
-        # 복원
         data = self.mgr.load_json_data()
-        for i, orig in originals.items():
-            if orig is not None and isinstance(data[i], dict):
-                data[i]["initialLevel"] = orig
-        self.mgr.save_json_data(data)
+        for a in data:
+            if isinstance(a, dict):
+                assert a["initialLevel"] == 5
 
     @pytest.mark.asyncio
     async def test_update_general_bulk_no_valid_fields(self) -> None:
@@ -312,12 +325,11 @@ class TestActorManager:
 
 class TestClassManagerExtended:
     @pytest.fixture(autouse=True)
-    def _setup(self):
-        self.mgr = ClassManager(_get_data_path(), "test_cls_ext")
+    def _setup(self, data_path: Path):
+        self.mgr = ClassManager(data_path, "test_cls_ext")
 
     @pytest.mark.asyncio
     async def test_update(self) -> None:
-        """클래스 생성 → update → 필드 확인."""
         unique = f"ZZZ_CLS_UPD_{uuid.uuid4().hex[:8]}"
         cr = await self.mgr.execute("create", class_name=unique)
         assert cr.get("success") is True
@@ -352,16 +364,7 @@ class TestClassManagerExtended:
 
     @pytest.mark.asyncio
     async def test_create_duplicate(self) -> None:
-        """이미 존재하는 클래스명으로 create → exists 에러."""
-        data = self.mgr.load_json_data()
-        first_name = None
-        for item in data:
-            if isinstance(item, dict) and item.get("name"):
-                first_name = item["name"]
-                break
-        assert first_name is not None
-
-        r = await self.mgr.execute("create", class_name=first_name)
+        r = await self.mgr.execute("create", class_name="전사")
         assert r.get("success") is False
         assert r.get("exists") is True
 
@@ -371,8 +374,8 @@ class TestClassManagerExtended:
 
 class TestSkillManager:
     @pytest.fixture(autouse=True)
-    def _setup(self):
-        self.mgr = SkillManager(_get_data_path(), "test_skill")
+    def _setup(self, data_path: Path):
+        self.mgr = SkillManager(data_path, "test_skill")
 
     @pytest.mark.asyncio
     async def test_add_skill(self) -> None:
@@ -383,16 +386,7 @@ class TestSkillManager:
 
     @pytest.mark.asyncio
     async def test_add_duplicate_skill(self) -> None:
-        """기본 데이터에 있는 스킬명으로 add → 실패."""
-        data = self.mgr.load_json_data()
-        first_name = None
-        for item in data:
-            if isinstance(item, dict) and item.get("name"):
-                first_name = item["name"]
-                break
-        assert first_name is not None
-
-        r = await self.mgr.execute("add", target_name=first_name)
+        r = await self.mgr.execute("add", target_name="공격")
         assert r.get("success") is False
 
     @pytest.mark.asyncio

--- a/agent/tests/test_managers.py
+++ b/agent/tests/test_managers.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import json
 import uuid
 from pathlib import Path
 
@@ -17,8 +16,10 @@ from app.backend.services.json_modify_tools.managers.class_manager import ClassM
 from app.backend.services.json_modify_tools.managers.skill_manager import SkillManager
 from app.backend.services.json_modify_tools.managers.system_manager import SystemManager
 
+
 def _get_data_path() -> Path:
     from app.backend.core.config import settings
+
     return Path(settings.STORAGE_PATH) / "game_001" / "data"
 
 
@@ -60,9 +61,7 @@ class TestSystemManager:
         assert system["variables"][5] == "test_var"
 
         # 복원
-        await self.mgr.execute(
-            "set_variable_name", target_info={"variable_id": 5, "name": ""}
-        )
+        await self.mgr.execute("set_variable_name", target_info={"variable_id": 5, "name": ""})
 
     @pytest.mark.asyncio
     async def test_set_variable_name_invalid_id(self) -> None:
@@ -81,9 +80,7 @@ class TestSystemManager:
         assert system["switches"][3] == "test_switch"
 
         # 복원
-        await self.mgr.execute(
-            "set_switch_name", target_info={"switch_id": 3, "name": ""}
-        )
+        await self.mgr.execute("set_switch_name", target_info={"switch_id": 3, "name": ""})
 
     @pytest.mark.asyncio
     async def test_update_starting_position(self) -> None:
@@ -211,7 +208,10 @@ class TestActorManager:
 
         r = await self.mgr.execute(
             "update_general",
-            target_info={"actor_id": actor_id, "updates": {"nickname": "테스트닉", "initialLevel": 10}},
+            target_info={
+                "actor_id": actor_id,
+                "updates": {"nickname": "테스트닉", "initialLevel": 10},
+            },
         )
         assert r.get("success") is True
         assert "nickname" in r.get("updated_fields", [])

--- a/agent/tests/test_managers.py
+++ b/agent/tests/test_managers.py
@@ -1,0 +1,419 @@
+"""Manager 단위 테스트 — SystemManager, ClassManager, ActorManager, SkillManager.
+
+로컬 game_001/data/ 의 실제 JSON을 사용한다.
+테스트에서 생성한 데이터는 고유 이름(ZZZ_ prefix)으로 충돌을 방지한다.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from app.backend.services.json_modify_tools.managers.actor_manager import ActorManager
+from app.backend.services.json_modify_tools.managers.class_manager import ClassManager
+from app.backend.services.json_modify_tools.managers.skill_manager import SkillManager
+from app.backend.services.json_modify_tools.managers.system_manager import SystemManager
+
+def _get_data_path() -> Path:
+    from app.backend.core.config import settings
+    return Path(settings.STORAGE_PATH) / "game_001" / "data"
+
+
+# ── SystemManager ────────────────────────────────────────────
+
+
+class TestSystemManager:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.mgr = SystemManager(_get_data_path(), "test_sys")
+
+    @pytest.mark.asyncio
+    async def test_update_game_title(self) -> None:
+        old_data = self.mgr.load_json_data()
+        old_title = old_data.get("gameTitle", "")
+
+        r = await self.mgr.execute(
+            "update_game_title", target_info={"game_title": "TEST_TITLE_TMP"}
+        )
+        assert r["success"] is True
+        assert r["old_title"] == old_title
+        assert r["new_title"] == "TEST_TITLE_TMP"
+
+        # 복원
+        await self.mgr.execute("update_game_title", target_info={"game_title": old_title})
+
+    @pytest.mark.asyncio
+    async def test_update_game_title_empty(self) -> None:
+        r = await self.mgr.execute("update_game_title", target_info={"game_title": ""})
+        assert r["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_set_variable_name(self) -> None:
+        r = await self.mgr.execute(
+            "set_variable_name", target_info={"variable_id": 5, "name": "test_var"}
+        )
+        assert r["success"] is True
+        system = self.mgr.load_json_data()
+        assert system["variables"][5] == "test_var"
+
+        # 복원
+        await self.mgr.execute(
+            "set_variable_name", target_info={"variable_id": 5, "name": ""}
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_variable_name_invalid_id(self) -> None:
+        r = await self.mgr.execute(
+            "set_variable_name", target_info={"variable_id": "abc", "name": "x"}
+        )
+        assert r["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_set_switch_name(self) -> None:
+        r = await self.mgr.execute(
+            "set_switch_name", target_info={"switch_id": 3, "name": "test_switch"}
+        )
+        assert r["success"] is True
+        system = self.mgr.load_json_data()
+        assert system["switches"][3] == "test_switch"
+
+        # 복원
+        await self.mgr.execute(
+            "set_switch_name", target_info={"switch_id": 3, "name": ""}
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_starting_position(self) -> None:
+        old = self.mgr.load_json_data()
+        old_map = old.get("startMapId")
+        old_x = old.get("startX")
+        old_y = old.get("startY")
+
+        r = await self.mgr.execute(
+            "update_starting_position",
+            target_info={"map_id": 2, "x": 10, "y": 20},
+        )
+        assert r["success"] is True
+
+        system = self.mgr.load_json_data()
+        assert system["startMapId"] == 2
+        assert system["startX"] == 10
+        assert system["startY"] == 20
+
+        # 복원
+        await self.mgr.execute(
+            "update_starting_position",
+            target_info={"map_id": old_map, "x": old_x, "y": old_y},
+        )
+
+    @pytest.mark.asyncio
+    async def test_unsupported_action(self) -> None:
+        r = await self.mgr.execute("unknown_action")
+        assert r["success"] is False
+
+
+# ── ClassManager ─────────────────────────────────────────────
+
+
+class TestClassManager:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.mgr = ClassManager(_get_data_path(), "test_cls")
+
+    @pytest.mark.asyncio
+    async def test_query_existing(self) -> None:
+        """기본 데이터에 있는 클래스를 조회."""
+        data = self.mgr.load_json_data()
+        # 첫 번째 실제 클래스 이름 찾기
+        first_name = None
+        for item in data:
+            if isinstance(item, dict) and item.get("name"):
+                first_name = item["name"]
+                break
+        assert first_name is not None
+
+        r = await self.mgr.execute("query", class_name=first_name)
+        assert r.get("exists") is True
+
+    @pytest.mark.asyncio
+    async def test_query_not_found(self) -> None:
+        r = await self.mgr.execute("query", class_name="ZZZ_NONEXISTENT_CLASS")
+        assert r.get("exists") is False
+
+    @pytest.mark.asyncio
+    async def test_create_and_query(self) -> None:
+        unique = f"ZZZ_CLS_{uuid.uuid4().hex[:8]}"
+        r = await self.mgr.execute("create", class_name=unique)
+        assert r.get("success") is True
+
+        q = await self.mgr.execute("query", class_name=unique)
+        assert q.get("exists") is True
+
+
+# ── ActorManager ─────────────────────────────────────────────
+
+
+class TestActorManager:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.mgr = ActorManager(_get_data_path(), "test_actor")
+
+    @pytest.mark.asyncio
+    async def test_query_existing_by_name(self) -> None:
+        """기본 데이터에 있는 액터를 이름으로 조회."""
+        data = self.mgr.load_json_data()
+        first_name = None
+        for item in data:
+            if isinstance(item, dict) and item.get("name"):
+                first_name = item["name"]
+                break
+        assert first_name is not None
+
+        r = await self.mgr.execute("query", actor_name=first_name)
+        assert r.get("exists") is True
+
+    @pytest.mark.asyncio
+    async def test_query_not_found(self) -> None:
+        r = await self.mgr.execute("query", actor_name="ZZZ_NONEXISTENT_ACTOR")
+        assert r.get("exists") is False
+
+    @pytest.mark.asyncio
+    async def test_list_actors(self) -> None:
+        r = await self.mgr.execute("list")
+        assert r.get("success") is True
+        assert "id=1:" in (r.get("stdout") or r.get("message") or "")
+
+    @pytest.mark.asyncio
+    async def test_search_actor(self) -> None:
+        """기본 데이터의 첫 액터 이름으로 검색."""
+        data = self.mgr.load_json_data()
+        first_name = None
+        for item in data:
+            if isinstance(item, dict) and item.get("name"):
+                first_name = item["name"]
+                break
+        assert first_name is not None
+
+        r = await self.mgr.execute("search", target_info={"searchTerm": first_name})
+        assert r.get("success") is True
+        assert r.get("exists") is True
+
+    @pytest.mark.asyncio
+    async def test_update_general(self) -> None:
+        """create → update_general → 복원."""
+        unique = f"ZZZ_UPD_{uuid.uuid4().hex[:8]}"
+        cr = await self.mgr.execute("create", actor_name=unique)
+        assert cr.get("success") is True
+        actor_id = cr.get("actor_id")
+
+        r = await self.mgr.execute(
+            "update_general",
+            target_info={"actor_id": actor_id, "updates": {"nickname": "테스트닉", "initialLevel": 10}},
+        )
+        assert r.get("success") is True
+        assert "nickname" in r.get("updated_fields", [])
+        assert "initialLevel" in r.get("updated_fields", [])
+
+        # 값 확인
+        data = self.mgr.load_json_data()
+        assert data[actor_id]["nickname"] == "테스트닉"
+        assert data[actor_id]["initialLevel"] == 10
+
+    @pytest.mark.asyncio
+    async def test_update_general_type_coercion(self) -> None:
+        """문자열 '10' → int 10 변환."""
+        unique = f"ZZZ_COERCE_{uuid.uuid4().hex[:8]}"
+        cr = await self.mgr.execute("create", actor_name=unique)
+        actor_id = cr.get("actor_id")
+
+        r = await self.mgr.execute(
+            "update_general",
+            target_info={"actor_id": actor_id, "updates": {"initialLevel": "15"}},
+        )
+        assert r.get("success") is True
+
+        data = self.mgr.load_json_data()
+        assert data[actor_id]["initialLevel"] == 15
+        assert isinstance(data[actor_id]["initialLevel"], int)
+
+    @pytest.mark.asyncio
+    async def test_update_general_invalid_actor_id(self) -> None:
+        r = await self.mgr.execute(
+            "update_general",
+            target_info={"actor_id": "abc", "updates": {"nickname": "x"}},
+        )
+        assert r.get("success") is False
+
+    @pytest.mark.asyncio
+    async def test_update_general_no_valid_fields(self) -> None:
+        """지원하지 않는 필드만 주면 실패."""
+        unique = f"ZZZ_NOFLD_{uuid.uuid4().hex[:8]}"
+        cr = await self.mgr.execute("create", actor_name=unique)
+        actor_id = cr.get("actor_id")
+
+        r = await self.mgr.execute(
+            "update_general",
+            target_info={"actor_id": actor_id, "updates": {"unknownField": 42}},
+        )
+        assert r.get("success") is False
+
+    @pytest.mark.asyncio
+    async def test_query_empty_name_fails(self) -> None:
+        """빈 actor_name은 에러."""
+        r = await self.mgr.execute("query", actor_name="")
+        assert r.get("success") is False
+
+    @pytest.mark.asyncio
+    async def test_query_by_id_out_of_range(self) -> None:
+        """범위 밖 actor_id — actor_name으로 검색하면 exists=False."""
+        r = await self.mgr.execute("query", actor_name="ZZZ_NEVER_EXISTS_99999")
+        assert r.get("exists") is False
+
+    @pytest.mark.asyncio
+    async def test_update_general_bulk(self) -> None:
+        """전체 액터에 일괄 필드 업데이트."""
+        data = self.mgr.load_json_data()
+        originals = {}
+        for i, a in enumerate(data):
+            if isinstance(a, dict):
+                originals[i] = a.get("initialLevel")
+
+        r = await self.mgr.execute(
+            "update_general_bulk",
+            target_info={
+                "selector": {"mode": "all"},
+                "updates": {"initialLevel": 5},
+            },
+        )
+        assert r.get("success") is True
+        assert r.get("updated_count", 0) > 0
+
+        # 복원
+        data = self.mgr.load_json_data()
+        for i, orig in originals.items():
+            if orig is not None and isinstance(data[i], dict):
+                data[i]["initialLevel"] = orig
+        self.mgr.save_json_data(data)
+
+    @pytest.mark.asyncio
+    async def test_update_general_bulk_no_valid_fields(self) -> None:
+        r = await self.mgr.execute(
+            "update_general_bulk",
+            target_info={"updates": {"unknownField": 42}},
+        )
+        assert r.get("success") is False
+
+
+# ── ClassManager 추가 테스트 ─────────────────────────────────
+
+
+class TestClassManagerExtended:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.mgr = ClassManager(_get_data_path(), "test_cls_ext")
+
+    @pytest.mark.asyncio
+    async def test_update(self) -> None:
+        """클래스 생성 → update → 필드 확인."""
+        unique = f"ZZZ_CLS_UPD_{uuid.uuid4().hex[:8]}"
+        cr = await self.mgr.execute("create", class_name=unique)
+        assert cr.get("success") is True
+        class_id = cr.get("class_id")
+
+        r = await self.mgr.execute(
+            "update",
+            target_info={"class_id": class_id, "updates": {"name": f"{unique}_RENAMED"}},
+        )
+        assert r.get("success") is True
+        assert "name" in r.get("updated_fields", [])
+
+    @pytest.mark.asyncio
+    async def test_update_invalid_id(self) -> None:
+        r = await self.mgr.execute(
+            "update",
+            target_info={"class_id": "abc", "updates": {"name": "x"}},
+        )
+        assert r.get("success") is False
+
+    @pytest.mark.asyncio
+    async def test_update_no_valid_fields(self) -> None:
+        unique = f"ZZZ_CLS_NF_{uuid.uuid4().hex[:8]}"
+        cr = await self.mgr.execute("create", class_name=unique)
+        class_id = cr.get("class_id")
+
+        r = await self.mgr.execute(
+            "update",
+            target_info={"class_id": class_id, "updates": {"badField": 42}},
+        )
+        assert r.get("success") is False
+
+    @pytest.mark.asyncio
+    async def test_create_duplicate(self) -> None:
+        """이미 존재하는 클래스명으로 create → exists 에러."""
+        data = self.mgr.load_json_data()
+        first_name = None
+        for item in data:
+            if isinstance(item, dict) and item.get("name"):
+                first_name = item["name"]
+                break
+        assert first_name is not None
+
+        r = await self.mgr.execute("create", class_name=first_name)
+        assert r.get("success") is False
+        assert r.get("exists") is True
+
+
+# ── SkillManager ─────────────────────────────────────────────
+
+
+class TestSkillManager:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.mgr = SkillManager(_get_data_path(), "test_skill")
+
+    @pytest.mark.asyncio
+    async def test_add_skill(self) -> None:
+        unique = f"ZZZ_SKILL_{uuid.uuid4().hex[:8]}"
+        r = await self.mgr.execute("add", target_name=unique, mpCost=10, description="테스트 스킬")
+        assert r.get("success") is True
+        assert r.get("target_name") == unique
+
+    @pytest.mark.asyncio
+    async def test_add_duplicate_skill(self) -> None:
+        """기본 데이터에 있는 스킬명으로 add → 실패."""
+        data = self.mgr.load_json_data()
+        first_name = None
+        for item in data:
+            if isinstance(item, dict) and item.get("name"):
+                first_name = item["name"]
+                break
+        assert first_name is not None
+
+        r = await self.mgr.execute("add", target_name=first_name)
+        assert r.get("success") is False
+
+    @pytest.mark.asyncio
+    async def test_update_skill(self) -> None:
+        unique = f"ZZZ_SKILL_UPD_{uuid.uuid4().hex[:8]}"
+        await self.mgr.execute("add", target_name=unique)
+
+        r = await self.mgr.execute("update", target_name=unique, mpCost=50, description="수정됨")
+        assert r.get("success") is True
+
+        data = self.mgr.load_json_data()
+        skill = next(s for s in data if isinstance(s, dict) and s.get("name") == unique)
+        assert skill["mpCost"] == 50
+        assert skill["description"] == "수정됨"
+
+    @pytest.mark.asyncio
+    async def test_update_nonexistent_skill(self) -> None:
+        r = await self.mgr.execute("update", target_name="ZZZ_NONEXISTENT_SKILL")
+        assert r.get("success") is False
+
+    @pytest.mark.asyncio
+    async def test_unsupported_action(self) -> None:
+        r = await self.mgr.execute("delete", target_name="x")
+        assert r.get("success") is False

--- a/agent/tests/test_mcp_toolbox.py
+++ b/agent/tests/test_mcp_toolbox.py
@@ -1,0 +1,341 @@
+"""mcp_toolbox 순수 함수 단위 테스트.
+
+외부 서비스(MCP 서버, LLM 등)를 호출하지 않는다.
+monkeypatch로 환경변수만 제어해 parse/resolve/sanitize 로직을 검증한다.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from agent import mcp_toolbox as mt
+
+
+# ──────────────────────────────────────────────────────────────
+# parse_mcp_servers_json
+# ──────────────────────────────────────────────────────────────
+
+
+class TestParseMcpServersJson:
+    """MCP_SERVERS_JSON 환경변수 파싱."""
+
+    def test_single_server(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_SERVERS_JSON", '{"default":{"node_path":"/a.js"}}')
+        result = mt.parse_mcp_servers_json()
+        assert result == {"default": {"node_path": "/a.js"}}
+
+    def test_multi_server(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "MCP_SERVERS_JSON",
+            '{"default":{"node_path":"/a.js"},"maker":{"command":"npx","args":["maker"]}}',
+        )
+        result = mt.parse_mcp_servers_json()
+        assert result is not None
+        assert len(result) == 2
+        assert "default" in result
+        assert "maker" in result
+
+    def test_empty_env_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MCP_SERVERS_JSON", raising=False)
+        assert mt.parse_mcp_servers_json() is None
+
+    def test_blank_string_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_SERVERS_JSON", "   ")
+        assert mt.parse_mcp_servers_json() is None
+
+    def test_invalid_json_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_SERVERS_JSON", "{{not json}}")
+        assert mt.parse_mcp_servers_json() is None
+
+    def test_json_array_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_SERVERS_JSON", '[1, 2, 3]')
+        assert mt.parse_mcp_servers_json() is None
+
+    def test_empty_dict_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_SERVERS_JSON", "{}")
+        assert mt.parse_mcp_servers_json() is None
+
+    def test_mixed_valid_invalid_entries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """유효한 항목(dict 값)만 남기고 비-dict 값은 필터링."""
+        monkeypatch.setenv(
+            "MCP_SERVERS_JSON",
+            '{"good":{"node_path":"/a.js"},"bad":"string_value","also_bad":123}',
+        )
+        result = mt.parse_mcp_servers_json()
+        assert result == {"good": {"node_path": "/a.js"}}
+
+
+# ──────────────────────────────────────────────────────────────
+# resolve_mcp_server_key — 엣지 케이스
+# ──────────────────────────────────────────────────────────────
+
+
+class TestResolveMcpServerKeyEdge:
+    """resolve_mcp_server_key 엣지 케이스 (기본 우선순위는 test_mcp_server_resolve.py에서 검증)."""
+
+    def test_explicit_whitespace_only_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """explicit_from_map이 공백만이면 None 취급 → tool/file 매핑으로 폴백."""
+        monkeypatch.setenv("MCP_SERVER_BY_TOOL_JSON", '{"get_actor":"by_tool"}')
+        monkeypatch.delenv("MCP_SERVER_BY_TARGET_FILE_JSON", raising=False)
+        result = mt.resolve_mcp_server_key("Actors.json", "get_actor", "   ")
+        # 공백만 있으면 strip 후 빈 문자열이므로 falsy → tool lookup으로 폴백
+        assert result == "by_tool"
+
+    def test_tool_name_none_skips_tool_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_SERVER_BY_TOOL_JSON", '{"get_actor":"by_tool"}')
+        monkeypatch.setenv("MCP_SERVER_BY_TARGET_FILE_JSON", '{"Actors.json":"by_file"}')
+        result = mt.resolve_mcp_server_key("Actors.json", None, None)
+        assert result == "by_file"
+
+    def test_empty_target_file_skips_file_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MCP_SERVER_BY_TOOL_JSON", raising=False)
+        monkeypatch.setenv("MCP_SERVER_BY_TARGET_FILE_JSON", '{"Actors.json":"by_file"}')
+        result = mt.resolve_mcp_server_key("", "unknown_tool", None)
+        assert result is None
+
+    def test_broken_tool_json_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MCP_SERVER_BY_TOOL_JSON이 깨진 JSON이면 무시하고 file 매핑으로 폴백."""
+        monkeypatch.setenv("MCP_SERVER_BY_TOOL_JSON", "not valid json")
+        monkeypatch.setenv("MCP_SERVER_BY_TARGET_FILE_JSON", '{"Actors.json":"by_file"}')
+        result = mt.resolve_mcp_server_key("Actors.json", "get_actor", None)
+        assert result == "by_file"
+
+    def test_file_json_non_string_value_filtered(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """값이 문자열이 아니면(int 등) 필터링되어 매칭 안 됨."""
+        monkeypatch.delenv("MCP_SERVER_BY_TOOL_JSON", raising=False)
+        monkeypatch.setenv("MCP_SERVER_BY_TARGET_FILE_JSON", '{"Actors.json":123}')
+        result = mt.resolve_mcp_server_key("Actors.json", "get_actor", None)
+        assert result is None
+
+    def test_tool_json_value_whitespace_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_SERVER_BY_TOOL_JSON", '{"get_actor":" maker "}')
+        monkeypatch.delenv("MCP_SERVER_BY_TARGET_FILE_JSON", raising=False)
+        result = mt.resolve_mcp_server_key("Actors.json", "get_actor", None)
+        assert result == "maker"
+
+
+# ──────────────────────────────────────────────────────────────
+# _sanitize_mz_item_effects_for_schema
+# ──────────────────────────────────────────────────────────────
+
+
+class TestSanitizeMzItemEffects:
+    """executor의 _sanitize_mz_item_effects_for_schema 테스트."""
+
+    @pytest.fixture(autouse=True)
+    def _load_executor(self):
+        self.executor_module = importlib.import_module("agent.graph.nodes.executor")
+
+    def test_swap_when_value1_gt_10_and_value2_zero(self) -> None:
+        """code=11, value1=500, value2=0 → value1=0, value2=500."""
+        effects = [{"code": 11, "value1": 500, "value2": 0}]
+        result = self.executor_module._sanitize_mz_item_effects_for_schema(effects)
+        assert result[0]["value1"] == 0
+        assert result[0]["value2"] == 500
+
+    def test_no_swap_when_value1_low(self) -> None:
+        """code=12, value1=5, value2=100 → 변경 없음."""
+        effects = [{"code": 12, "value1": 5, "value2": 100}]
+        result = self.executor_module._sanitize_mz_item_effects_for_schema(effects)
+        assert result[0]["value1"] == 5
+        assert result[0]["value2"] == 100
+
+    def test_non_list_returns_empty(self) -> None:
+        assert self.executor_module._sanitize_mz_item_effects_for_schema(None) == []
+        assert self.executor_module._sanitize_mz_item_effects_for_schema("string") == []
+
+    def test_non_dict_entries_skipped(self) -> None:
+        effects = [42, None, "x", {"code": 11, "value1": 0, "value2": 50}]
+        result = self.executor_module._sanitize_mz_item_effects_for_schema(effects)
+        assert len(result) == 1
+        assert result[0]["code"] == 11
+
+    def test_code_not_11_12_no_swap(self) -> None:
+        """code=21(상태 부여)은 swap 대상이 아님."""
+        effects = [{"code": 21, "value1": 500, "value2": 0}]
+        result = self.executor_module._sanitize_mz_item_effects_for_schema(effects)
+        assert result[0]["value1"] == 500
+        assert result[0]["value2"] == 0
+
+    def test_empty_list(self) -> None:
+        assert self.executor_module._sanitize_mz_item_effects_for_schema([]) == []
+
+    def test_value_type_error_fallback(self) -> None:
+        """value가 비숫자이면 float 변환 실패 → 0.0으로 폴백, swap 안 함."""
+        effects = [{"code": 11, "value1": "abc", "value2": "def"}]
+        result = self.executor_module._sanitize_mz_item_effects_for_schema(effects)
+        # v1n=0.0, v2n=0.0 → v1n <= 10이므로 swap 안 함
+        assert result[0]["value1"] == "abc"
+        assert result[0]["value2"] == "def"
+
+
+# ──────────────────────────────────────────────────────────────
+# is_mcp_enabled
+# ──────────────────────────────────────────────────────────────
+
+
+# ──────────────────────────────────────────────────────────────
+# filter_category_labels (Definition 지칭어 필터링)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestFilterCategoryLabels:
+    """definition.filter_category_labels 순수 로직 테스트."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        from agent.graph.nodes.definition import filter_category_labels
+
+        self.fn = filter_category_labels
+
+    def test_concrete_only_kept(self) -> None:
+        """구체 이름만 있으면 그대로 유지."""
+        cls = [{"name": "루시퍼", "category": "actor", "is_category_label": False}]
+        assert self.fn(cls) == cls
+
+    def test_label_only_kept(self) -> None:
+        """지칭어만 있으면(예: '액터 전부 삭제') 그대로 유지."""
+        cls = [{"name": "액터", "category": "actor", "is_category_label": True}]
+        assert self.fn(cls) == cls
+
+    def test_concrete_plus_label_removes_label(self) -> None:
+        """'루시퍼 액터 추가' → 구체 이름 + 지칭어 → 지칭어 제거."""
+        cls = [
+            {"name": "루시퍼", "category": "actor", "is_category_label": False},
+            {"name": "액터", "category": "actor", "is_category_label": True},
+        ]
+        result = self.fn(cls)
+        assert len(result) == 1
+        assert result[0]["name"] == "루시퍼"
+
+    def test_concrete_plus_different_category_label_removes_label(self) -> None:
+        """구체 이름(actor) + 다른 카테고리 지칭어(item) → 지칭어 모두 제거."""
+        cls = [
+            {"name": "루시퍼", "category": "actor", "is_category_label": False},
+            {"name": "아이템", "category": "item", "is_category_label": True},
+        ]
+        result = self.fn(cls)
+        assert len(result) == 1
+        assert result[0]["name"] == "루시퍼"
+
+    def test_multiple_labels_only_all_kept(self) -> None:
+        """지칭어만 여러 개 → 모두 유지."""
+        cls = [
+            {"name": "액터", "category": "actor", "is_category_label": True},
+            {"name": "아이템", "category": "item", "is_category_label": True},
+        ]
+        assert self.fn(cls) == cls
+
+    def test_multiple_concrete_no_labels(self) -> None:
+        """구체 이름 여러 개, 지칭어 없음 → 모두 유지."""
+        cls = [
+            {"name": "루시퍼", "category": "actor", "is_category_label": False},
+            {"name": "포션", "category": "item", "is_category_label": False},
+        ]
+        assert self.fn(cls) == cls
+
+    def test_empty_list(self) -> None:
+        assert self.fn([]) == []
+
+
+# ──────────────────────────────────────────────────────────────
+# is_mcp_enabled
+# ──────────────────────────────────────────────────────────────
+
+
+class TestIsMcpEnabled:
+    def test_true_variants(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for val in ("1", "true", "True", "YES", " True "):
+            monkeypatch.setenv("MCP_ENABLED", val)
+            assert mt.is_mcp_enabled() is True, f"MCP_ENABLED={val!r} should be True"
+
+    def test_false_variants(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for val in ("", "false", "0", "no"):
+            monkeypatch.setenv("MCP_ENABLED", val)
+            assert mt.is_mcp_enabled() is False, f"MCP_ENABLED={val!r} should be False"
+
+    def test_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MCP_ENABLED", raising=False)
+        assert mt.is_mcp_enabled() is False
+
+
+# ──────────────────────────────────────────────────────────────
+# get_mcp_server_args
+# ──────────────────────────────────────────────────────────────
+
+
+class TestGetMcpServerArgs:
+    def test_json_array(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_ARGS", '["/a", "/b"]')
+        assert mt.get_mcp_server_args() == ["/a", "/b"]
+
+    def test_plain_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_ARGS", "/a/b.js")
+        assert mt.get_mcp_server_args() == ["/a/b.js"]
+
+    def test_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_ARGS", "")
+        assert mt.get_mcp_server_args() == []
+
+    def test_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MCP_ARGS", raising=False)
+        assert mt.get_mcp_server_args() == []
+
+    def test_invalid_json_array(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_ARGS", '[broken')
+        assert mt.get_mcp_server_args() == ['[broken']
+
+
+# ──────────────────────────────────────────────────────────────
+# get_mcp_stdio_env
+# ──────────────────────────────────────────────────────────────
+
+
+class TestGetMcpStdioEnv:
+    def test_valid_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_ENV_JSON", '{"KEY":"VAL"}')
+        assert mt.get_mcp_stdio_env() == {"KEY": "VAL"}
+
+    def test_invalid_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_ENV_JSON", "not json")
+        assert mt.get_mcp_stdio_env() == {}
+
+    def test_not_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_ENV_JSON", '["a","b"]')
+        assert mt.get_mcp_stdio_env() == {}
+
+    def test_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_ENV_JSON", "")
+        assert mt.get_mcp_stdio_env() == {}
+
+
+# ──────────────────────────────────────────────────────────────
+# _is_path_under_storage_root
+# ──────────────────────────────────────────────────────────────
+
+
+class TestIsPathUnderStorageRoot:
+    def test_valid_path(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        from app.backend.core.config import settings
+
+        storage = tmp_path / "storage" / "games"
+        storage.mkdir(parents=True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(storage))
+
+        candidate = storage / "game_001" / "data"
+        candidate.mkdir(parents=True)
+        assert mt._is_path_under_storage_root(candidate) is True
+
+    def test_traversal_blocked(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        from app.backend.core.config import settings
+
+        storage = tmp_path / "storage" / "games"
+        storage.mkdir(parents=True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(storage))
+
+        evil = tmp_path / "etc" / "passwd"
+        evil.parent.mkdir(parents=True, exist_ok=True)
+        evil.touch()
+        assert mt._is_path_under_storage_root(evil) is False

--- a/agent/tests/test_mcp_toolbox.py
+++ b/agent/tests/test_mcp_toolbox.py
@@ -12,7 +12,6 @@ import pytest
 
 from agent import mcp_toolbox as mt
 
-
 # ──────────────────────────────────────────────────────────────
 # parse_mcp_servers_json
 # ──────────────────────────────────────────────────────────────
@@ -50,7 +49,7 @@ class TestParseMcpServersJson:
         assert mt.parse_mcp_servers_json() is None
 
     def test_json_array_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("MCP_SERVERS_JSON", '[1, 2, 3]')
+        monkeypatch.setenv("MCP_SERVERS_JSON", "[1, 2, 3]")
         assert mt.parse_mcp_servers_json() is None
 
     def test_empty_dict_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -284,8 +283,8 @@ class TestGetMcpServerArgs:
         assert mt.get_mcp_server_args() == []
 
     def test_invalid_json_array(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("MCP_ARGS", '[broken')
-        assert mt.get_mcp_server_args() == ['[broken']
+        monkeypatch.setenv("MCP_ARGS", "[broken")
+        assert mt.get_mcp_server_args() == ["[broken"]
 
 
 # ──────────────────────────────────────────────────────────────

--- a/agent/tests/test_planner.py
+++ b/agent/tests/test_planner.py
@@ -7,7 +7,7 @@
 
 [ 실행 방법 ]
   # 결과 출력 없이 검증만
-  uv run pytest agent/tests/test_planner.py -v
+  uv run pytest agent/tests/test_planner.py -v -m integration
 
   # LLM이 실제로 만든 execution_plan 내용까지 출력
   uv run pytest agent/tests/test_planner.py -v -s
@@ -26,6 +26,8 @@ import pytest
 
 from agent.graph.nodes.planner import planner
 from agent.graph.state import AgentState
+
+pytestmark = pytest.mark.integration
 
 # ──────────────────────────────────────────────────────────────
 # 공통 헬퍼

--- a/agent/tests/test_synthesizer_prompt.py
+++ b/agent/tests/test_synthesizer_prompt.py
@@ -1,0 +1,101 @@
+"""synthesizer_prompt 스냅샷 비교 순수 로직 테스트.
+
+LLM 호출 없이 dict 비교 함수만 검증한다.
+"""
+
+from __future__ import annotations
+
+from agent.prompts.synthesizer_prompt import (
+    _extract_actual_changes,
+    _extract_actual_changes_from_snapshots,
+)
+
+
+# ── _extract_actual_changes_from_snapshots ───────────────────
+
+
+class TestExtractActualChangesFromSnapshots:
+    def test_dict_field_changed(self) -> None:
+        """System.json 같은 단일 dict에서 필드 변경 감지."""
+        before = {"System.json": {"gameTitle": "Old", "startX": 0}}
+        after = {"System.json": {"gameTitle": "New", "startX": 0}}
+        result = _extract_actual_changes_from_snapshots(before, after)
+        assert len(result) == 1
+        assert "gameTitle" in result[0]
+        assert "`Old`" in result[0]
+        assert "`New`" in result[0]
+
+    def test_no_change_returns_empty(self) -> None:
+        before = {"System.json": {"gameTitle": "Same"}}
+        after = {"System.json": {"gameTitle": "Same"}}
+        assert _extract_actual_changes_from_snapshots(before, after) == []
+
+    def test_array_item_changed(self) -> None:
+        """Actors.json 같은 배열에서 항목 필드 변경 감지."""
+        before = {"Actors.json": [None, {"id": 1, "name": "Hero", "maxLevel": 50}]}
+        after = {"Actors.json": [None, {"id": 1, "name": "Hero", "maxLevel": 99}]}
+        result = _extract_actual_changes_from_snapshots(before, after)
+        assert len(result) == 1
+        assert "maxLevel" in result[0]
+        assert "Hero" in result[0]
+
+    def test_empty_snapshots(self) -> None:
+        assert _extract_actual_changes_from_snapshots({}, {}) == []
+
+    def test_new_file_in_modified(self) -> None:
+        """수정 스냅샷에만 존재하는 파일 — before가 {}이므로 모든 필드가 변경."""
+        before = {}
+        after = {"System.json": {"gameTitle": "New"}}
+        result = _extract_actual_changes_from_snapshots(before, after)
+        assert len(result) == 1
+
+    def test_array_null_items_skipped(self) -> None:
+        """null 항목은 건너뛴다."""
+        before = {"Actors.json": [None, None]}
+        after = {"Actors.json": [None, None]}
+        assert _extract_actual_changes_from_snapshots(before, after) == []
+
+    def test_multiple_files_changes(self) -> None:
+        """여러 파일에서 동시 변경."""
+        before = {
+            "System.json": {"gameTitle": "Old"},
+            "Actors.json": [None, {"id": 1, "name": "A", "hp": 100}],
+        }
+        after = {
+            "System.json": {"gameTitle": "New"},
+            "Actors.json": [None, {"id": 1, "name": "A", "hp": 200}],
+        }
+        result = _extract_actual_changes_from_snapshots(before, after)
+        assert len(result) == 2
+
+
+# ── _extract_actual_changes ──────────────────────────────────
+
+
+class TestExtractActualChanges:
+    def test_array_item_changed(self) -> None:
+        before = {"Actors.json": [None, {"id": 1, "name": "Hero", "maxLevel": 50}]}
+        after = {"Actors.json": [None, {"id": 1, "name": "Hero", "maxLevel": 99}]}
+        changes = _extract_actual_changes(before, after)
+        key = "Actors.json[Hero]"
+        assert key in changes
+        assert changes[key]["maxLevel"] == {"before": 50, "after": 99}
+
+    def test_no_change_returns_empty(self) -> None:
+        data = {"Actors.json": [None, {"id": 1, "name": "Hero"}]}
+        assert _extract_actual_changes(data, data) == {}
+
+    def test_dict_file_skipped(self) -> None:
+        """System.json(단일 dict)은 이 함수에서 처리하지 않는다."""
+        before = {"System.json": {"gameTitle": "Old"}}
+        after = {"System.json": {"gameTitle": "New"}}
+        assert _extract_actual_changes(before, after) == {}
+
+    def test_multiple_fields_changed(self) -> None:
+        before = {"Items.json": [None, {"id": 1, "name": "Potion", "price": 50, "scope": 7}]}
+        after = {"Items.json": [None, {"id": 1, "name": "Hi-Potion", "price": 100, "scope": 7}]}
+        changes = _extract_actual_changes(before, after)
+        item_changes = list(changes.values())[0]
+        assert "name" in item_changes
+        assert "price" in item_changes
+        assert "scope" not in item_changes

--- a/agent/tests/test_synthesizer_prompt.py
+++ b/agent/tests/test_synthesizer_prompt.py
@@ -10,7 +10,6 @@ from agent.prompts.synthesizer_prompt import (
     _extract_actual_changes_from_snapshots,
 )
 
-
 # ── _extract_actual_changes_from_snapshots ───────────────────
 
 

--- a/agent/tests/test_validator.py
+++ b/agent/tests/test_validator.py
@@ -9,13 +9,12 @@ import types
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, patch  # noqa: F401 — kept for potential future use
 
 import pytest
 
 from agent.graph.nodes.validator import (
     FileValidationResult,
-    StepValidationLLMResult,
     ValidationErrorItem,
     ValidatorOutput,
     validator,
@@ -491,21 +490,9 @@ def _print_debug_block(title: str, value: Any) -> None:
 
 @pytest.fixture(autouse=True)
 def mock_step_validation_llm():
-    async def _mock_invoke(_messages, structured_output=None):
-        if structured_output is None:
-            return "ok"
-        return structured_output.model_validate(
-            {
-                "is_match": True,
-                "reasoning": "planner step and executor log are aligned",
-            }
-        )
-
-    with patch(
-        "agent.graph.nodes.validator.invoke_llm",
-        new=AsyncMock(side_effect=_mock_invoke),
-    ):
-        yield
+    # validator가 code-first(스키마 검증만)로 변경되어 invoke_llm을 사용하지 않음.
+    # LLM mock 없이 그대로 실행.
+    yield
 
 
 @pytest.mark.asyncio
@@ -513,17 +500,15 @@ async def test_validator_validates_all_modified_game_state_files():
     state = _base_validator_state()
     result = await validator(state)
 
-    assert result["success"] is True
-    assert "retry_count" not in result
-    assert "validation_result" not in result
-    assert [item["target"] for item in result["validation_results"]] == [
-        "Actors.json",
-        "Classes.json",
-        "System.json",
+    # 기본 state는 query 없이 create → query_consistency 실패하지만 스키마는 통과
+    schema_results = [
+        item for item in result["validation_results"] if item["category"] == "schema"
     ]
-    assert result["validation_summary"] == "총 3개 파일이 모두 스키마 검증을 통과했습니다."
-    assert all("message" not in item for item in result["validation_results"])
-    assert all("error_count" not in item for item in result["validation_results"])
+    schema_targets = [item["target"] for item in schema_results]
+    assert "Actors.json" in schema_targets
+    assert "Classes.json" in schema_targets
+    assert "System.json" in schema_targets
+    assert all(item["success"] for item in schema_results)
 
 
 @pytest.mark.asyncio
@@ -550,18 +535,13 @@ async def test_validator_supports_snapshot_path_inputs(tmp_path: Path):
     )
 
     assert result == expected
-    assert result["success"] is True
-    assert "retry_count" not in result
-    assert "validation_result" not in result
-    assert [item["target"] for item in result["validation_results"]] == [
-        "Actors.json",
-        "Classes.json",
-        "System.json",
-        "Map001.json",
+    schema_results = [
+        item for item in result["validation_results"] if item["category"] == "schema"
     ]
-    assert result["validation_summary"] == "총 4개 파일이 모두 스키마 검증을 통과했습니다."
-    assert all("message" not in item for item in result["validation_results"])
-    assert all("error_count" not in item for item in result["validation_results"])
+    schema_targets = [item["target"] for item in schema_results]
+    assert "Actors.json" in schema_targets
+    assert "Map001.json" in schema_targets
+    assert all(item["success"] for item in schema_results)
 
 
 @pytest.mark.asyncio
@@ -572,16 +552,14 @@ async def test_validator_schema_failure_increments_retry_count():
 
     assert result["success"] is False
     assert result["retry_count"] == 1
-    assert result["validation_summary"] == "총 3개 파일 중 1개 파일 검증에 실패했습니다."
-    assert "validation_result" not in result
-    actor_result = next(
-        item for item in result["validation_results"] if item["target"] == "Actors.json"
-    )
-    assert actor_result["success"] is False
-    assert "message" not in actor_result
-    assert "error_count" not in actor_result
-    assert len(actor_result["errors"]) > 0
-    assert sum(len(item["errors"]) for item in result["validation_results"]) > 0
+    assert "스키마 실패" in result["validation_summary"]
+    actor_results = [
+        item for item in result["validation_results"]
+        if item["target"] == "Actors.json" and item["category"] == "schema"
+    ]
+    assert len(actor_results) == 1
+    assert actor_results[0]["success"] is False
+    assert len(actor_results[0]["errors"]) > 0
 
 
 @pytest.mark.asyncio
@@ -595,11 +573,11 @@ async def test_validator_validates_only_files_present_in_modified_game_state():
     result = await validator(state)
     contract = ValidatorOutput.model_validate(result)
 
-    assert contract.success is True
-    assert contract.retry_count is None
-    assert [item.target for item in contract.validation_results] == ["Actors.json"]
-    assert "Unknown.json" not in [item.target for item in contract.validation_results]
-    assert result["validation_summary"] == "총 1개 파일이 모두 스키마 검증을 통과했습니다."
+    schema_targets = [
+        item.target for item in contract.validation_results if item.category == "schema"
+    ]
+    assert "Actors.json" in schema_targets
+    assert "Unknown.json" not in schema_targets
 
 
 @pytest.mark.asyncio
@@ -612,13 +590,9 @@ async def test_validator_unsupported_schema_returns_standard_shape():
         item for item in result["validation_results"] if item["target"] == "Unknown.json"
     )
     assert unknown_result["success"] is False
-    assert "message" not in unknown_result
-    assert "error_count" not in unknown_result
-    assert unknown_result["errors"][0]["msg"] == "unsupported schema for Unknown.json"
+    assert "unsupported schema" in unknown_result["errors"][0]["msg"]
     assert result["success"] is False
     assert result["retry_count"] == 1
-    assert "validation_result" not in result
-    assert result["validation_summary"] == "총 4개 파일 중 1개 파일 검증에 실패했습니다."
 
 
 @pytest.mark.asyncio
@@ -641,40 +615,43 @@ async def test_validator_empty_modified_game_state_increments_retry_count():
 
 
 @pytest.mark.asyncio
-async def test_validator_missing_execution_plan_returns_state_error():
+async def test_validator_missing_execution_plan_skips_step_validation():
+    """execution_plan이 없으면 step 검증을 건너뛰고 스키마 검증만 수행."""
     state = _base_validator_state()
     state.pop("execution_plan")
 
     result = await validator(state)
     contract = ValidatorOutput.model_validate(result)
 
-    assert contract.success is False
-    assert contract.retry_count == 1
-    assert contract.validation_summary == "execution_plan is missing or empty."
-    assert len(contract.validation_results) == 1
-    assert contract.validation_results[0].target == "state"
-    assert contract.validation_results[0].errors[0].msg == "execution_plan is missing or empty."
+    # 스키마 검증은 통과
+    assert contract.success is True
+    assert contract.retry_count == 0
+    # step 검증 결과가 없어야 함
+    step_results = [item for item in contract.validation_results if item.target.startswith("step:")]
+    assert len(step_results) == 0
 
 
 @pytest.mark.asyncio
-async def test_validator_step_validation_missing_executor_log_adds_failure():
+async def test_validator_partial_changes_log_still_validates_schema():
+    """changes_log에서 step 2가 빠져도 스키마 검증은 정상 수행."""
     state = _base_validator_state()
     state["changes_log"] = [state["changes_log"][0]]
 
     result = await validator(state)
 
-    assert result["success"] is False
-    assert result["retry_count"] == 1
-    step_result = next(item for item in result["validation_results"] if item["target"] == "step:2")
-    assert step_result["success"] is False
-    assert "changes_log에 없습니다" in step_result["errors"][0]["msg"]
+    schema_results = [
+        item for item in result["validation_results"] if item["category"] == "schema"
+    ]
+    assert all(item["success"] for item in schema_results)
 
 
 @pytest.mark.asyncio
-async def test_validator_step_validation_executor_failure_adds_failure():
+async def test_validator_executor_failure_in_log_still_validates_schema():
+    """executor가 실패해도 스키마 검증은 수행."""
     state = _base_validator_state()
     state["changes_log"][1] = {
         "step_id": 2,
+        "target_file": "System.json",
         "tool_name": "structured_system_update",
         "success": False,
         "error": "executor failed",
@@ -682,31 +659,14 @@ async def test_validator_step_validation_executor_failure_adds_failure():
 
     result = await validator(state)
 
-    assert result["success"] is False
-    assert result["retry_count"] == 1
-    step_result = next(item for item in result["validation_results"] if item["target"] == "step:2")
-    assert "executor failed" in step_result["errors"][0]["msg"]
+    schema_results = [
+        item for item in result["validation_results"] if item["category"] == "schema"
+    ]
+    assert all(item["success"] for item in schema_results)
 
 
 @pytest.mark.asyncio
-async def test_validator_step_validation_llm_mismatch_adds_failure():
-    state = _base_validator_state()
-
-    with patch("agent.graph.nodes.validator.invoke_llm", new_callable=AsyncMock) as mock_llm:
-        mock_llm.return_value = StepValidationLLMResult(
-            is_match=False,
-            reasoning="planner step은 System.json update인데 executor tool_name이 다른 작업으로 판정됨",
-        )
-        result = await validator(state)
-
-    assert result["success"] is False
-    assert result["retry_count"] == 1
-    step_result = next(item for item in result["validation_results"] if item["target"] == "step:1")
-    assert "planner step은" in step_result["errors"][0]["msg"]
-
-
-@pytest.mark.asyncio
-async def test_validator_query_step_allows_empty_modified_files_when_llm_matches():
+async def test_validator_query_step_allows_empty_modified_files():
     state = _base_validator_state()
     state["execution_plan"] = [
         {
@@ -722,17 +682,21 @@ async def test_validator_query_step_allows_empty_modified_files_when_llm_matches
     state["changes_log"] = [
         {
             "step_id": 1,
+            "target_file": "Actors.json",
             "tool_name": "structured_actors_query",
             "success": True,
             "modified_files": [],
+            "exists": False,
         }
     ]
-
+    # query만 있으면 modified_game_state에서 Actors.json 스키마 검증만 수행
     result = await validator(state)
-
-    assert result["success"] is True
-    assert "retry_count" not in result
-    assert all(item["target"] != "step:1" for item in result["validation_results"])
+    # query 스텝 자체는 성공이어야 함
+    step1_failures = [
+        item for item in result["validation_results"]
+        if item["target"] == "step:1" and not item["success"]
+    ]
+    assert len(step1_failures) == 0
 
 
 @pytest.mark.asyncio
@@ -745,7 +709,12 @@ async def test_validator_debug_print_execution_plan_changes_log_and_result():
     _print_debug_block("changes_log", state["changes_log"])
     _print_debug_block("validator_result", result)
 
-    assert result["success"] is True
+    # 기본 state는 query 없이 create → query_consistency 실패 가능
+    # 최소한 스키마 검증은 통과해야 함
+    schema_results = [
+        item for item in result["validation_results"] if item["category"] == "schema"
+    ]
+    assert all(item["success"] for item in schema_results)
 
 
 if __name__ == "__main__":

--- a/agent/tests/test_validator.py
+++ b/agent/tests/test_validator.py
@@ -501,9 +501,7 @@ async def test_validator_validates_all_modified_game_state_files():
     result = await validator(state)
 
     # 기본 state는 query 없이 create → query_consistency 실패하지만 스키마는 통과
-    schema_results = [
-        item for item in result["validation_results"] if item["category"] == "schema"
-    ]
+    schema_results = [item for item in result["validation_results"] if item["category"] == "schema"]
     schema_targets = [item["target"] for item in schema_results]
     assert "Actors.json" in schema_targets
     assert "Classes.json" in schema_targets
@@ -535,9 +533,7 @@ async def test_validator_supports_snapshot_path_inputs(tmp_path: Path):
     )
 
     assert result == expected
-    schema_results = [
-        item for item in result["validation_results"] if item["category"] == "schema"
-    ]
+    schema_results = [item for item in result["validation_results"] if item["category"] == "schema"]
     schema_targets = [item["target"] for item in schema_results]
     assert "Actors.json" in schema_targets
     assert "Map001.json" in schema_targets
@@ -554,7 +550,8 @@ async def test_validator_schema_failure_increments_retry_count():
     assert result["retry_count"] == 1
     assert "스키마 실패" in result["validation_summary"]
     actor_results = [
-        item for item in result["validation_results"]
+        item
+        for item in result["validation_results"]
         if item["target"] == "Actors.json" and item["category"] == "schema"
     ]
     assert len(actor_results) == 1
@@ -639,9 +636,7 @@ async def test_validator_partial_changes_log_still_validates_schema():
 
     result = await validator(state)
 
-    schema_results = [
-        item for item in result["validation_results"] if item["category"] == "schema"
-    ]
+    schema_results = [item for item in result["validation_results"] if item["category"] == "schema"]
     assert all(item["success"] for item in schema_results)
 
 
@@ -659,9 +654,7 @@ async def test_validator_executor_failure_in_log_still_validates_schema():
 
     result = await validator(state)
 
-    schema_results = [
-        item for item in result["validation_results"] if item["category"] == "schema"
-    ]
+    schema_results = [item for item in result["validation_results"] if item["category"] == "schema"]
     assert all(item["success"] for item in schema_results)
 
 
@@ -693,7 +686,8 @@ async def test_validator_query_step_allows_empty_modified_files():
     result = await validator(state)
     # query 스텝 자체는 성공이어야 함
     step1_failures = [
-        item for item in result["validation_results"]
+        item
+        for item in result["validation_results"]
         if item["target"] == "step:1" and not item["success"]
     ]
     assert len(step1_failures) == 0
@@ -711,9 +705,7 @@ async def test_validator_debug_print_execution_plan_changes_log_and_result():
 
     # 기본 state는 query 없이 create → query_consistency 실패 가능
     # 최소한 스키마 검증은 통과해야 함
-    schema_results = [
-        item for item in result["validation_results"] if item["category"] == "schema"
-    ]
+    schema_results = [item for item in result["validation_results"] if item["category"] == "schema"]
     assert all(item["success"] for item in schema_results)
 
 

--- a/app/backend/tests/test_services/test_game_service.py
+++ b/app/backend/tests/test_services/test_game_service.py
@@ -114,7 +114,7 @@ class TestDeleteProject:
         self, db_session: AsyncSession, test_project: Project
     ):
         """프로젝트 삭제 시 _game_locks에서 해당 lock이 제거되는지 확인."""
-        from app.backend.services.llm_service import _game_locks
+        from app.backend.services.session_manager import _game_locks
 
         game_id = test_project.game_id
         # lock을 미리 생성해둠

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,23 @@ asyncio_mode = "auto"
 testpaths = ["app/backend/tests", "agent/tests"]
 markers = ["integration: 실제 LLM API 호출이 필요한 통합 테스트 (API 키 필요)"]
 
+[tool.coverage.run]
+source = ["agent", "app/backend"]
+omit = [
+    "agent/tests/*",
+    "app/backend/tests/*",
+    "*/check_*.py",
+    "*/integration_*_test.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["agent", "app/backend", "shared"]
 
@@ -87,4 +104,5 @@ dev = [
     "pre-commit>=4.5.1",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -492,6 +492,90 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.6"
 source = { registry = "https://pypi.org/simple" }
@@ -3108,6 +3192,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3280,6 +3378,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -3325,6 +3424,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
 ]
 
 [[package]]
@@ -3762,6 +3862,7 @@ dependencies = [
     { name = "numpy" },
     { name = "scikit-learn" },
     { name = "scipy" },
+    { name = "torch" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "typing-extensions" },
@@ -4072,6 +4173,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/3f/49fa63422159bbc2f2a4ac5bfc597d04d4ec0ad3d2ef46649b5e9a340e37/tokenizers-0.20.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a4c186bb006ccbe1f5cc4e0380d1ce7806f5955c244074fd96abc55e27b77f01", size = 9303950, upload-time = "2024-11-05T17:31:50.674Z" },
     { url = "https://files.pythonhosted.org/packages/66/11/79d91aeb2817ad1993ef61c690afe73e6dbedbfb21918b302ef5a2ba9bfb/tokenizers-0.20.3-cp313-none-win32.whl", hash = "sha256:6e19e0f1d854d6ab7ea0c743d06e764d1d9a546932be0a67f33087645f00fe13", size = 2188941, upload-time = "2024-11-05T17:31:53.334Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/ac8410f868fb8b14b5e619efa304aa119cb8a40bd7df29fc81a898e64f99/tokenizers-0.20.3-cp313-none-win_amd64.whl", hash = "sha256:d50ede425c7e60966a9680d41b58b3a0950afa1bb570488e2972fa61662c4273", size = 2380269, upload-time = "2024-11-05T17:31:54.796Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
+    { url = "https://files.pythonhosted.org/packages/13/16/42e5915ebe4868caa6bac83a8ed59db57f12e9a61b7d749d584776ed53d5/torch-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f99924682ef0aa6a4ab3b1b76f40dc6e273fca09f367d15a524266db100a723f", size = 419731115, upload-time = "2026-03-23T18:11:06.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c9/82638ef24d7877510f83baf821f5619a61b45568ce21c0a87a91576510aa/torch-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0f68f4ac6d95d12e896c3b7a912b5871619542ec54d3649cf48cc1edd4dd2756", size = 530712279, upload-time = "2026-03-23T18:10:31.481Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ff/6756f1c7ee302f6d202120e0f4f05b432b839908f9071157302cedfc5232/torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10", size = 114556047, upload-time = "2026-03-23T18:10:55.931Z" },
+    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d1/8ed2173589cbfe744ed54e5a73efc107c0085ba5777ee93a5f4c1ab90553/torch-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:63a68fa59de8f87acc7e85a5478bb2dddbb3392b7593ec3e78827c793c4b73fd", size = 419732382, upload-time = "2026-03-23T18:08:30.835Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e1/b73f7c575a4b8f87a5928f50a1e35416b5e27295d8be9397d5293e7e8d4c/torch-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cc89b9b173d9adfab59fd227f0ab5e5516d9a52b658ae41d64e59d2e55a418db", size = 530711509, upload-time = "2026-03-23T18:08:47.213Z" },
+    { url = "https://files.pythonhosted.org/packages/66/82/3e3fcdd388fbe54e29fd3f991f36846ff4ac90b0d0181e9c8f7236565f82/torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd", size = 114555842, upload-time = "2026-03-23T18:09:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/6c/56bfb37073e7136e6dd86bfc6af7339946dd684e0ecf2155ac0eee687ae1/torch-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2658f34ce7e2dabf4ec73b45e2ca68aedad7a5be87ea756ad656eaf32bf1e1ea", size = 419732324, upload-time = "2026-03-23T18:09:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/1b666b6d61d3394cca306ea543ed03a64aad0a201b6cd159f1d41010aeb1/torch-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98bb213c3084cfe176302949bdc360074b18a9da7ab59ef2edc9d9f742504778", size = 530596026, upload-time = "2026-03-23T18:09:20.842Z" },
+    { url = "https://files.pythonhosted.org/packages/48/6b/30d1459fa7e4b67e9e3fe1685ca1d8bb4ce7c62ef436c3a615963c6c866c/torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db", size = 114793702, upload-time = "2026-03-23T18:09:47.304Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0d/8603382f61abd0db35841148ddc1ffd607bf3100b11c6e1dab6d2fc44e72/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7", size = 80573442, upload-time = "2026-03-23T18:09:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/86/7cd7c66cb9cec6be330fff36db5bd0eef386d80c031b581ec81be1d4b26c/torch-2.11.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2bb3cc54bd0dea126b0060bb1ec9de0f9c7f7342d93d436646516b0330cd5be7", size = 419749385, upload-time = "2026-03-23T18:07:33.77Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e8/b98ca2d39b2e0e4730c0ee52537e488e7008025bc77ca89552ff91021f7c/torch-2.11.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4dc8b3809469b6c30b411bb8c4cad3828efd26236153d9beb6a3ec500f211a60", size = 530716756, upload-time = "2026-03-23T18:07:50.02Z" },
+    { url = "https://files.pythonhosted.org/packages/78/88/d4a4cda8362f8a30d1ed428564878c3cafb0d87971fbd3947d4c84552095/torch-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:2b4e811728bd0cc58fb2b0948fe939a1ee2bf1422f6025be2fca4c7bd9d79718", size = 114552300, upload-time = "2026-03-23T18:09:05.617Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/46/4419098ed6d801750f26567b478fc185c3432e11e2cad712bc6b4c2ab0d0/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8245477871c3700d4370352ffec94b103cfcb737229445cf9946cddb7b2ca7cd", size = 80959460, upload-time = "2026-03-23T18:09:00.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/66/54a56a4a6ceaffb567231994a9745821d3af922a854ed33b0b3a278e0a99/torch-2.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:ab9a8482f475f9ba20e12db84b0e55e2f58784bdca43a854a6ccd3fd4b9f75e6", size = 419735835, upload-time = "2026-03-23T18:07:18.974Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e7/0b6665f533aa9e337662dc190425abc0af1fe3234088f4454c52393ded61/torch-2.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:563ed3d25542d7e7bbc5b235ccfacfeb97fb470c7fee257eae599adb8005c8a2", size = 530613405, upload-time = "2026-03-23T18:08:07.014Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bf/c8d12a2c86dbfd7f40fb2f56fbf5a505ccf2d9ce131eb559dfc7c51e1a04/torch-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b2a43985ff5ef6ddd923bbcf99943e5f58059805787c5c9a2622bf05ca2965b0", size = 114792991, upload-time = "2026-03-23T18:08:19.216Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
1. 테스트 코드만 추가하고 기존 동작에는 변화가 없습니다. 
2. 추가로 테스트 커버리지를 볼 수 있도록 dev 패키지를 추가하였습니다. (외부 의존성과 관련된 테스트는 커버리지가 낮음)
3. 이 PR은 Agent/Backend 테스트만 다룹니다.

**(*제가 남긴 코멘트 위주로 보시고 테스트 코드 자체는 스킵하셔도 됩니다)**

## 변경 요약

**345개 테스트 전체 통과, 커버리지 67% (이전 대비 +13%p)**

### 무엇이 나아졌는가

| 지표 | 이전 | 이후 | 변화 |
|------|------|------|------|
| **전체 테스트 수** | 36 passed, 9 failed | **345 passed, 0 failed** | +309개, 실패 0 |
| **전체 커버리지** | 54% | **67%** | **+13%p** |

### 핵심 모듈별 커버리지

| 모듈 | 이전 | 이후 | 변화 |
|------|------|------|------|
| `synthesizer_prompt.py` | 10% | **94%** | +84%p |
| `game_paths.py` | 36% | **92%** | +56%p |
| `skill_manager.py` | 53% | **91%** | +38%p |
| `game_data_io.py` | 13% | **87%** | +74%p |
| `system_manager.py` | 37% | **84%** | +47%p |
| `class_manager.py` | 47% | **81%** | +34%p |
| `executor.py` | 66% | **74%** | +8%p |
| `actor_manager.py` | 59% | **72%** | +13%p |
| `definition.py` | 10% | **62%** | +52%p |
| `mcp_toolbox.py` | 35% | **50%** | +15%p |
| `validator.py` | 16% | **48%** | +32%p |

### 비즈니스 로직 수정 (2건, 동작 변경 없음)

1. **`executor.py`** — Items/Enemies create에 `game_locks` 추가 (동시 쓰기 방지)
2. **`definition.py`** — 인라인 지칭어 필터링을 `filter_category_labels()` 함수로 추출 (리팩터링만)

---

## 왜 이 작업을 했나

`feat/jc_lee/workflow` 브랜치에서 다중 MCP 서버 라우팅, Items/Enemies 구조화 생성 등 큰 기능이 추가되었다. 하지만 테스트 커버리지가 부족해서, 변경 사항이 안전한지 확인하기 어려운 상태였다.

- 기존 9개 테스트가 실제 파일에 의존해서 환경 없으면 실패
- `_structured_create_enemy_sync`, `parse_mcp_servers_json` 등 핵심 함수 테스트 0개
- Items/Enemies 구조화 생성 시 `game_locks` 없이 동시 쓰기 레이스 컨디션 위험
- `validator.py` 테스트가 이전 LLM 기반 버전 기준이라 현재 code-first 버전과 불일치
- 테스트 커버리지 측정 도구 없음

## 어떻게 해결했나

### 1. 테스트 환경 격리 (`conftest.py`)

backend conftest가 `STORAGE_PATH`를 임시 디렉토리로 패치하면, agent 테스트가 게임 데이터를 찾지 못하는 문제가 있었다.

**해결**: `agent/tests/conftest.py`에 `autouse` fixture를 추가해서, `STORAGE_PATH`가 임시 디렉토리인 경우에만 `base_game/data/`를 매 테스트마다 복사·초기화한다. 실제 프로젝트 경로에서는 복사하지 않으므로 agent 단독 실행 시에도 안전하다.

```python
@pytest.fixture(autouse=True)
def _ensure_test_game_data():
    storage_path = Path(settings.STORAGE_PATH).resolve()
    if storage_path == _REAL_STORAGE.resolve():
        return  # 실제 경로면 복사 불필요
    # 임시 디렉토리인 경우에만 base_game에서 복사
    ...
```

### 2. 테스트 코드 추가 (8개 파일)

모든 테스트는 외부 서비스(LLM, MCP 서버, DB, S3) 호출 없이 동작한다.

#### `test_mcp_toolbox.py` (신규, 42개)
- `parse_mcp_servers_json` 파싱 (8개)
- `resolve_mcp_server_key` 엣지 케이스 (6개)
- `_sanitize_mz_item_effects_for_schema` 보정 (7개)
- `filter_category_labels` 지칭어 필터링 (7개)
- `is_mcp_enabled`, `get_mcp_server_args`, `get_mcp_stdio_env`, `_is_path_under_storage_root` (14개)

#### `test_executor_mvp.py` (확장, 45개)
- 기존 25개 수정 (하드코딩 경로 → `settings.STORAGE_PATH` 기반)
- Items 실패/엣지 10개, Enemies 성공/실패/엣지 10개

#### `test_executor_helpers.py` (신규, 36개)
- `_coerce_list_from_mcp_search_payload`, `_first_numeric_id_from_row`, `_row_name_matches_search_term` 등 순수 헬퍼
- `_items_local_search_by_name`, `_actors_local_search_by_name`, `_skills_local_search_by_name` 로컬 검색
- `_normalize_mcp_arguments` 인자 정규화, `_enrich_items_target_info_from_deps` 의존성 상속

#### `test_game_data_io.py` (신규, 19개)
- `read_game_json`, `write_game_json`, `read_game_json_fields` 읽기/쓰기
- `get_next_entity_id`, `get_next_append_id_streaming`, `get_next_empty_slot_id_streaming` ID 탐색
- `get_system_context` 시스템 컨텍스트 추출

#### `test_synthesizer_prompt.py` (신규, 11개)
- `_extract_actual_changes_from_snapshots` 스냅샷 비교 (7개)
- `_extract_actual_changes` 변경 필드 추출 (4개)

#### `test_managers.py` (신규, 31개)
- `SystemManager`: update_game_title, set_variable_name, set_switch_name, update_starting_position 등 (7개)
- `ActorManager`: query, list, search, update_general, update_general_bulk 등 (13개)
- `ClassManager`: query, create, update, create_duplicate 등 (7개)
- `SkillManager`: add, update, duplicate, unsupported action 등 (5개)

#### `test_game_paths.py` (신규, 6개)
- `ensure_rpgmaker_mz_project_shell`: 루트 파일 복사, css/ 복사, js/ 심볼릭 링크, 기존 파일 보존, base/game_root 미존재

#### `test_validator.py` (수정, 11개)
- `StepValidationLLMResult` import 제거 (validator에서 삭제된 클래스)
- LLM mock fixture를 no-op으로 변경 (code-first 방식으로 변경됨)
- assertion을 현재 validator 동작에 맞게 수정 (validation_summary 형식, retry_count 항상 포함, query_consistency)

### 3. 기존 코드 수정 (테스트 코드)

- `test_game_service.py`: `_game_locks` import를 `llm_service` → `session_manager`로 수정 (소스 이동 반영)
- `test_executor_mvp.py`, `test_managers.py`: 하드코딩 경로를 `settings.STORAGE_PATH` 기반으로 변경

### 4. 커버리지 도구 추가

- `pytest-cov`를 `dev` 의존성 그룹에 추가 (`uv add --group dev pytest-cov`)
- `pyproject.toml`에 `[tool.coverage.run]`/`[tool.coverage.report]` 설정 추가

## 실행 방법

```bash
# agent 테스트만
python -m pytest agent/tests/ -v

# 전체 테스트 + 커버리지
python -m pytest --cov --cov-report=term-missing

# HTML 리포트
python -m pytest --cov --cov-report=html
```

## 결과

### 345/345 passed, 전체 커버리지 67%

| 파일 | 테스트 수 |
|------|----------|
| `test_mcp_toolbox.py` (신규) | 42개 |
| `test_executor_mvp.py` (확장) | 45개 |
| `test_executor_helpers.py` (신규) | 36개 |
| `test_managers.py` (신규) | 31개 |
| `test_game_data_io.py` (신규) | 19개 |
| `test_synthesizer_prompt.py` (신규) | 11개 |
| `test_validator.py` (수정) | 11개 |
| `test_game_paths.py` (신규) | 6개 |
| `test_mcp_server_resolve.py` (기존) | 4개 |
| 기타 기존 테스트 | 140개 |
| **합계** | **345개** |

### 변경된 파일 목록

| 파일 | 작업 |
|------|------|
| `agent/graph/nodes/executor.py` | Items/Enemies create에 `game_locks` 적용 |
| `agent/graph/nodes/definition.py` | `filter_category_labels()` 함수 추출 |
| `agent/tests/conftest.py` | **신규** — 테스트 환경 격리 (STORAGE_PATH 임시 디렉토리 대응) |
| `agent/tests/test_mcp_toolbox.py` | **신규** — 42개 테스트 |
| `agent/tests/test_executor_mvp.py` | 경로 수정 + 20개 추가 |
| `agent/tests/test_executor_helpers.py` | **신규** — 36개 테스트 |
| `agent/tests/test_game_data_io.py` | **신규** — 19개 테스트 |
| `agent/tests/test_synthesizer_prompt.py` | **신규** — 11개 테스트 |
| `agent/tests/test_managers.py` | **신규** — 31개 테스트 |
| `agent/tests/test_game_paths.py` | **신규** — 6개 테스트 |
| `agent/tests/test_validator.py` | LLM→code-first 대응 수정 |
| `app/backend/tests/test_services/test_game_service.py` | `_game_locks` import 경로 수정 |
| `pyproject.toml` | coverage 설정 + pytest-cov 의존성 |
