### PR TITLE
chore(docker): 배포 이미지에 다중 MCP 빌드·compose build args·예시 env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,16 @@ MAX_PROJECTS_PER_USER=3
 # agent/graph/nodes/executor.py 의 MCP_TOOL_MAP 항목에 "mcp_server":"키" 를 넣으면 위 env 라우팅보다 우선합니다.
 MCP_ENABLED=true
 
+# [로컬 예시]
+# MCP_DEFAULT_SERVER=default
+# MCP_SERVERS_JSON={"default":{"node_path":"/Users/you/mcp/-rpgmaker-mz-mcp/dist/index.js","cwd":"/Users/you/mcp/-rpgmaker-mz-mcp"},"mcp_maker":{"node_path":"/Users/you/mcp/MCP-Maker/dist/index.js","cwd":"/Users/you/mcp/MCP-Maker"},"rpgmaker_lower":{"node_path":"/Users/you/mcp/rpgmaker-mz-mcp/dist/index.js","cwd":"/Users/you/mcp/rpgmaker-mz-mcp"},"rpgmaker_underscore":{"node_path":"/Users/you/mcp/RPGMakerMZ_MCP/dist/index.js","cwd":"/Users/you/mcp/RPGMakerMZ_MCP"}}
+# MCP_SERVER_BY_TARGET_FILE_JSON={"Actors.json":"default","Skills.json":"mcp_maker","Items.json":"rpgmaker_lower","Weapons.json":"rpgmaker_underscore","Armors.json":"rpgmaker_underscore","System.json":"default"}
+
+# [배포 예시: docker/backend.Dockerfile 에 4개 MCP가 포함된 경우]
+# MCP_DEFAULT_SERVER=default
+# MCP_SERVERS_JSON={"default":{"node_path":"/app/mcp/default/dist/index.js","cwd":"/app/mcp/default"},"mcp_maker":{"node_path":"/app/mcp/mcp_maker/dist/index.js","cwd":"/app/mcp/mcp_maker"},"rpgmaker_lower":{"node_path":"/app/mcp/rpgmaker_lower/dist/index.js","cwd":"/app/mcp/rpgmaker_lower"},"rpgmaker_underscore":{"node_path":"/app/mcp/rpgmaker_underscore/dist/index.js","cwd":"/app/mcp/rpgmaker_underscore"}}
+# MCP_SERVER_BY_TARGET_FILE_JSON={"Actors.json":"default","Skills.json":"mcp_maker","Items.json":"rpgmaker_lower","Weapons.json":"rpgmaker_underscore","Armors.json":"rpgmaker_underscore","System.json":"default"}
+
 # 로컬로 실행할 경우 아래 주석 해제
 # MCP_NODE_SERVER_PATH=C:\Users\yebin\Desktop\-rpgmaker-mz-mcp\dist\index.js
 # MCP_CWD=C:\Users\yebin\Desktop\-rpgmaker-mz-mcp

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,6 +7,12 @@ services:
     build:
       context: .
       dockerfile: docker/backend.Dockerfile
+      args:
+        # 다중 MCP 리포 URL (비워두면 해당 키는 빌드 스킵)
+        MCP_REPO_DEFAULT: ${MCP_REPO_DEFAULT:-https://github.com/k4zuki0539/-rpgmaker-mz-mcp.git}
+        MCP_REPO_MAKER: ${MCP_REPO_MAKER:-}
+        MCP_REPO_LOWER: ${MCP_REPO_LOWER:-}
+        MCP_REPO_UNDERSCORE: ${MCP_REPO_UNDERSCORE:-}
     ports:
       - "8000:8000"  # EC2에서 외부 접근 허용
     env_file: .env

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -5,14 +5,40 @@
 # ------------------------------------------------------------
 # Stage 1: RPG Maker MZ MCP 서버 빌드 (Node)
 # - stdio MCP는 백엔드 컨테이너 내부에 실행파일이 있어야 함
-# - 여기서 git clone + build를 수행하고, 런타임 이미지로 산출물만 복사한다.
+# - 4개 MCP를 각각 clone + build 후 /mcp/<key> 로 모은다.
 # ------------------------------------------------------------
 FROM node:20-alpine AS mcp-builder
 WORKDIR /mcp
-RUN apk add --no-cache git
-RUN git clone https://github.com/k4zuki0539/-rpgmaker-mz-mcp.git .
-RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
-RUN npm run build
+RUN apk add --no-cache git bash
+
+# 기본값은 현재 운영 중인 리포 1개만 지정.
+# 나머지 3개는 docker-compose.prod.yml 또는 CI ENV_FILE에서 URL을 주입.
+ARG MCP_REPO_DEFAULT=https://github.com/k4zuki0539/-rpgmaker-mz-mcp.git
+ARG MCP_REPO_MAKER=
+ARG MCP_REPO_LOWER=
+ARG MCP_REPO_UNDERSCORE=
+
+RUN set -eux; \
+    mkdir -p /mcp/default /mcp/mcp_maker /mcp/rpgmaker_lower /mcp/rpgmaker_underscore; \
+    build_one() { \
+      key="$1"; \
+      url="$2"; \
+      if [ -z "$url" ]; then \
+        echo "skip $key (repo url empty)"; \
+        return 0; \
+      fi; \
+      work="/tmp/src-$key"; \
+      rm -rf "$work"; \
+      git clone "$url" "$work"; \
+      cd "$work"; \
+      if [ -f package-lock.json ]; then npm ci; else npm install; fi; \
+      npm run build; \
+      cp -R "$work"/. "/mcp/$key/"; \
+    }; \
+    build_one default "$MCP_REPO_DEFAULT"; \
+    build_one mcp_maker "$MCP_REPO_MAKER"; \
+    build_one rpgmaker_lower "$MCP_REPO_LOWER"; \
+    build_one rpgmaker_underscore "$MCP_REPO_UNDERSCORE"
 
 FROM python:3.12-slim
 
@@ -28,8 +54,10 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # MCP 빌드 산출물을 런타임 이미지에 포함 (컨테이너 내부 경로 기준)
-# - MCP_NODE_SERVER_PATH는 기본적으로 아래 경로를 가리키게 설정한다.
-COPY --from=mcp-builder /mcp /app/mcp-server
+# - 다중 MCP 루트: /app/mcp/<key>
+# - 기존 단일 경로 호환: /app/mcp-server -> /app/mcp/default
+COPY --from=mcp-builder /mcp /app/mcp
+RUN ln -s /app/mcp/default /app/mcp-server
 ENV MCP_NODE_SERVER_PATH=/app/mcp-server/dist/index.js
 
 # uv 설치


### PR DESCRIPTION
## 목적

- EC2/프로덕션 Docker 이미지에서도 **로컬과 동일하게 여러 stdio MCP 바이너리**를 선택적으로 포함할 수 있게 한다.
- `docker compose ... --build` 시 **빌드 인자(`MCP_REPO_*`)로 각 MCP Git URL**을 주입할 수 있게 한다.
- `.env.example`에 **로컬 경로 vs 컨테이너 경로** 기준 `MCP_SERVERS_JSON` 예시를 명시해 배포 설정 실수를 줄인다.

## 변경 요약

### `docker/backend.Dockerfile`

- `mcp-builder` 스테이지에서 최대 4개 MCP를 각각 `git clone → npm ci|install → npm run build` 후 `/mcp/<key>/`에 수집.
- `ARG`:
  - `MCP_REPO_DEFAULT` (기본값: k4zuki `-rpgmaker-mz-mcp`)
  - `MCP_REPO_MAKER`, `MCP_REPO_LOWER`, `MCP_REPO_UNDERSCORE` (비어 있으면 해당 키 빌드 스킵)
- 런타임 이미지에는 `/app/mcp/<key>/`로 복사.
- **하위 호환**: `/app/mcp-server` → `/app/mcp/default` **심볼릭 링크** 유지 (`MCP_NODE_SERVER_PATH=/app/mcp-server/dist/index.js` 계속 사용 가능).

### `docker-compose.prod.yml`

- `backend` 서비스 `build.args`에 `MCP_REPO_*` 연결.
- compose/EC2 `.env`에서 `${MCP_REPO_*}` 값을 주면 Dockerfile `ARG`로 전달됨.

### `.env.example`

- `[로컬 예시]` / `[배포 예시]` 블록으로 `MCP_SERVERS_JSON`, `MCP_SERVER_BY_TARGET_FILE_JSON` 샘플 추가 (주석).

## 배포 시 주의사항 (리뷰어/운영)

1. **4개 MCP를 모두 쓰려면** GitHub `ENV_FILE`(또는 EC2 `.env`)에 다음이 필요:
   - 빌드: `MCP_REPO_DEFAULT`, `MCP_REPO_MAKER`, `MCP_REPO_LOWER`, `MCP_REPO_UNDERSCORE` (공개 clone 가능한 URL)
   - 런타임: `MCP_SERVERS_JSON`, `MCP_SERVER_BY_TARGET_FILE_JSON` 등은 **`/app/mcp/...` 경로**로 설정 (로컬 `/Users/...` 금지)
2. **단일 MCP만 쓰면** `MCP_REPO_*` 중 나머지는 비워 두고, 런타임도 `default` 한 키만 쓰면 됨.
3. CD는 `main` 기준 `deploy.yml`이 EC2에서 `docker compose ... --build` 하므로, **이 PR이 `main`에 머지된 뒤** 이미지가 재빌드되어야 반영됨.

## 테스트 / 검증 방법

- 로컬(선택):  
  `docker compose -f docker-compose.yml -f docker-compose.prod.yml build backend`  
  (필요 시 `.env`에 `MCP_REPO_*` 설정)
- 배포 후(EC2, 선택): 컨테이너 내부에서  
  `/app/mcp/default/dist/index.js` 존재 확인, 4개 빌드 시 나머지 키 경로도 존재 확인.

## 관련 파일

- `docker/backend.Dockerfile`
- `docker-compose.prod.yml`
- `.env.example`

## 리스크

- MCP 4개 URL을 모두 채우면 **빌드 시간·네트워크 의존**이 커질 수 있음 (의도된 트레이드오프).
- 비공개 저장소 URL이면 빌드 실패 가능 → 공개 repo 또는 빌드 컨텍스트/자격 증명 전략 별도 필요.