### PR TITLE
feat(agent): 통합 MCP 연동 정리 및 아이템 생성·DB 툴 정규화

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -20,18 +20,16 @@ BASE_GAME_PATH=./storage/games/base_game
 STORAGE_BACKEND=local
 MAX_PROJECTS_PER_USER=3
 
-# ── MCP (RPG Maker MZ stdio server) ──────────────────────────
+# ── MCP (통합 integration_MCP — 로컬 폴더) ───────────────────
 MCP_ENABLED=true
 MCP_PATH_ARG_NAME=targetDir
+MCP_NODE_SERVER_PATH=/path/to/integration_MCP/dist/index.js
+MCP_CWD=/path/to/integration_MCP
 
-# [다중 MCP]
-MCP_DEFAULT_SERVER=default
-MCP_SERVERS_JSON={"default":{"node_path":".\Re-Verse\mcp\-rpgmaker-mz-mcp\dist\index.js","cwd":".\Re-Verse\mcp\-rpgmaker-mz-mcp"},"mcp_maker":{"node_path":".\Re-Verse\mcp\MCP-Maker\dist\index.js","cwd":".\Re-Verse\mcp\MCP-Maker"},"rpgmaker_lower":{"node_path":".\Re-Verse\mcp\rpgmaker-mz-mcp\dist\index.js","cwd":".\Re-Verse\mcp\mcp\rpgmaker-mz-mcp"},"rpgmaker_underscore":{"node_path":".\Re-Verse\mcp\mcp\RPGMakerMZ_MCP\dist\index.js","cwd":".\Re-Verse\mcp\RPGMakerMZ_MCP"}}
-MCP_SERVER_BY_TARGET_FILE_JSON={"Actors.json":"default","Skills.json":"mcp_maker","Items.json":"rpgmaker_lower","Weapons.json":"rpgmaker_underscore","Armors.json":"rpgmaker_underscore","System.json":"default"}
-
-# [단일 MCP]
-# MCP_NODE_SERVER_PATH=C:\Users\yebin\Desktop\-rpgmaker-mz-mcp\dist\index.js
-# MCP_CWD=C:\Users\yebin\Desktop\-rpgmaker-mz-mcp
+# [다중 MCP_SERVERS_JSON(레거시) — 단일 경로만 쓸 때는 불필요]
+# MCP_DEFAULT_SERVER=default
+# MCP_SERVERS_JSON={...}
+# MCP_SERVER_BY_TARGET_FILE_JSON={...}
 
 # ── AWS S3 (EC2 IAM 역할 사용 시 ACCESS_KEY 불필요) ───────────
 AWS_REGION=us-east-1

--- a/.env.production.example
+++ b/.env.production.example
@@ -20,18 +20,17 @@ BASE_GAME_PATH=/app/storage/games/base_game
 STORAGE_BACKEND=s3
 MAX_PROJECTS_PER_USER=3
 
-# ── MCP (RPG Maker MZ stdio server) ──────────────────────────
+# ── MCP (통합 1개 — Docker 이미지에 포함된 빌드 산출물) ───────
+# Dockerfile mcp-builder가 MCP_REPO를 clone·npm run build 후 /app/mcp-server 로 심링크
 MCP_ENABLED=true
 MCP_PATH_ARG_NAME=targetDir
+MCP_NODE_SERVER_PATH=/app/mcp-server/dist/index.js
+MCP_CWD=/app/mcp-server
 
-# [다중 MCP]
-MCP_DEFAULT_SERVER=default
-MCP_SERVERS_JSON={"default":{"node_path":"/app/mcp/default/dist/index.js","cwd":"/app/mcp/default"},"mcp_maker":{"node_path":"/app/mcp/mcp_maker/dist/index.js","cwd":"/app/mcp/mcp_maker"},"rpgmaker_lower":{"node_path":"/app/mcp/rpgmaker_lower/dist/index.js","cwd":"/app/mcp/rpgmaker_lower"},"rpgmaker_underscore":{"node_path":"/app/mcp/rpgmaker_underscore/dist/index.js","cwd":"/app/mcp/rpgmaker_underscore"}}
-MCP_SERVER_BY_TARGET_FILE_JSON={"Actors.json":"default","Skills.json":"mcp_maker","Items.json":"rpgmaker_lower","Weapons.json":"rpgmaker_underscore","Armors.json":"rpgmaker_underscore","System.json":"default"}
-
-# [단일 MCP]
-# MCP_NODE_SERVER_PATH=/app/mcp-server/dist/index.js
-# MCP_CWD=/app/mcp-server
+# [다중 MCP_SERVERS_JSON(레거시) — 단일 경로만 쓸 때는 불필요]
+# MCP_DEFAULT_SERVER=default
+# MCP_SERVERS_JSON={...}
+# MCP_SERVER_BY_TARGET_FILE_JSON={...}
 
 # ── AWS S3 (EC2 IAM 역할 사용 시 ACCESS_KEY 불필요) ───────────
 AWS_REGION=us-east-1

--- a/agent/graph/nodes/executor.py
+++ b/agent/graph/nodes/executor.py
@@ -58,20 +58,18 @@ game_locks: defaultdict[str, asyncio.Lock] = defaultdict(lambda: asyncio.Lock())
 # MCP (k4zuki RPG Maker MZ Node 서버) — 구조화 스텝만 인터셉트
 # (target_file, action_type) → list_tools() 이름과 동일. 맵 전용 툴(get_map*, *map_event*, add_event_command)은 제외.
 #
-# 없는 것: Classes.json / Enemies.json 등 — 이 MCP 리포에 해당 툴이 없음(액터·아이템·스킬·시스템 일부만).
-# Actors.json `update`는 레거시(ActorManager 클래스 변경)용이므로 MCP `update_actor`는 action `update_actor`로 구분.
+# 통합 MCP (integration_MCP / @rein634/rpg-maker-mz-mcp) 기준 툴 매핑.
+# 4개 리포를 하나로 합친 서버가 제공하는 tool 이름에 맞춤.
 # ────────────────────────────────────────────────────────────
 MCP_TOOL_MAP: dict[tuple[str, str], dict[str, Any]] = {
-    # (선택) "mcp_server": "MCP_SERVERS_JSON" 키 — 없으면 .env 의 MCP_SERVER_BY_TOOL_JSON /
-    # MCP_SERVER_BY_TARGET_FILE_JSON → MCP_DEFAULT_SERVER 순으로 결정.
     # Actors.json
-    ("Actors.json", "list"): {"tool": "get_actors", "backup_files": []},
+    ("Actors.json", "list"): {"tool": "list_actors", "backup_files": []},
     ("Actors.json", "search"): {"tool": "search_actors", "backup_files": []},
     ("Actors.json", "query_by_id"): {"tool": "get_actor", "backup_files": []},
     ("Actors.json", "create"): {"tool": "create_actor", "backup_files": ["Actors.json"]},
     ("Actors.json", "update_actor"): {"tool": "update_actor", "backup_files": ["Actors.json"]},
     # Skills.json
-    ("Skills.json", "list"): {"tool": "get_skills", "backup_files": []},
+    ("Skills.json", "list"): {"tool": "list_skills", "backup_files": []},
     ("Skills.json", "query"): {"tool": "get_skill", "backup_files": []},
     ("Skills.json", "search"): {"tool": "search_skills", "backup_files": []},
     ("Skills.json", "create"): {"tool": "create_skill", "backup_files": ["Skills.json"]},
@@ -90,13 +88,31 @@ MCP_TOOL_MAP: dict[tuple[str, str], dict[str, Any]] = {
     },
     ("Skills.json", "update"): {"tool": "update_skill", "backup_files": ["Skills.json"]},
     # Items.json
-    ("Items.json", "list"): {"tool": "get_items", "backup_files": []},
+    ("Items.json", "list"): {"tool": "list_items", "backup_files": []},
     ("Items.json", "search"): {"tool": "search_items", "backup_files": []},
+    ("Items.json", "create"): {"tool": "create_item", "backup_files": ["Items.json"]},
     ("Items.json", "update"): {"tool": "update_item", "backup_files": ["Items.json"]},
-    # Weapons.json / Armors.json (MCP는 조회만 제공)
-    ("Weapons.json", "list"): {"tool": "get_weapons", "backup_files": []},
-    ("Armors.json", "list"): {"tool": "get_armors", "backup_files": []},
-    # System.json (맵 편집 툴 제외, 시작 위치·타이틀·변수·스위치 이름 등)
+    # Weapons.json
+    ("Weapons.json", "list"): {"tool": "list_weapons", "backup_files": []},
+    ("Weapons.json", "create"): {"tool": "create_weapon", "backup_files": ["Weapons.json"]},
+    ("Weapons.json", "update"): {"tool": "update_weapon", "backup_files": ["Weapons.json"]},
+    # Armors.json
+    ("Armors.json", "list"): {"tool": "list_armors", "backup_files": []},
+    ("Armors.json", "create"): {"tool": "create_armor", "backup_files": ["Armors.json"]},
+    ("Armors.json", "update"): {"tool": "update_armor", "backup_files": ["Armors.json"]},
+    # Classes.json (통합 MCP에서 추가)
+    ("Classes.json", "list"): {"tool": "list_classes", "backup_files": []},
+    ("Classes.json", "create"): {"tool": "create_class", "backup_files": ["Classes.json"]},
+    ("Classes.json", "update"): {"tool": "update_class", "backup_files": ["Classes.json"]},
+    # States.json (통합 MCP에서 추가)
+    ("States.json", "list"): {"tool": "list_states", "backup_files": []},
+    ("States.json", "create"): {"tool": "create_state", "backup_files": ["States.json"]},
+    ("States.json", "update"): {"tool": "update_state", "backup_files": ["States.json"]},
+    # Enemies.json (통합 MCP에서 추가)
+    ("Enemies.json", "list"): {"tool": "list_enemies", "backup_files": []},
+    ("Enemies.json", "create"): {"tool": "create_enemy", "backup_files": ["Enemies.json"]},
+    ("Enemies.json", "update"): {"tool": "update_enemy", "backup_files": ["Enemies.json"]},
+    # System.json
     ("System.json", "query"): {"tool": "get_system", "backup_files": []},
     ("System.json", "list_variables"): {"tool": "get_variables", "backup_files": []},
     ("System.json", "set_variable_name"): {
@@ -249,6 +265,34 @@ def _skills_local_search_by_name(data_path: Path, term: str) -> tuple[bool, int 
     return False, None
 
 
+def _enemies_local_search_by_name(data_path: Path, term: str) -> tuple[bool, int | None]:
+    t = (term or "").strip().lower()
+    if not t:
+        return False, None
+    fp = data_path / "Enemies.json"
+    if not fp.is_file():
+        return False, None
+    try:
+        raw = json.loads(fp.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False, None
+    if not isinstance(raw, list):
+        return False, None
+    for idx, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip().lower()
+        if not name:
+            continue
+        if t in name:
+            rid = entry.get("id")
+            try:
+                return True, int(rid) if rid is not None else idx
+            except (TypeError, ValueError):
+                return True, idx
+    return False, None
+
+
 def _enrich_mcp_search_tool_result(
     tool_name: str,
     r: dict[str, Any],
@@ -271,6 +315,7 @@ def _enrich_mcp_search_tool_result(
         "search_items": (("id", "itemId"), _items_local_search_by_name),
         "search_actors": (("id", "actorId"), _actors_local_search_by_name),
         "search_skills": (("id", "skillId"), _skills_local_search_by_name),
+        "search_enemies": (("id", "enemyId"), _enemies_local_search_by_name),
     }
     if tool_name not in cfg:
         return out
@@ -304,6 +349,8 @@ def _enrich_mcp_search_tool_result(
             out["actor_id"] = first_id
         elif tool_name == "search_skills":
             out["skill_id"] = first_id
+        elif tool_name == "search_enemies":
+            out["enemy_id"] = first_id
     return out
 
 
@@ -422,6 +469,11 @@ def _normalize_mcp_arguments(
         return out
 
     # ── Items.json ──
+    if target_file == "Items.json" and action == "create":
+        if "name" not in out and "item_name" in out:
+            out["name"] = out.pop("item_name")
+        return out
+
     if target_file == "Items.json" and action == "search":
         # query→search 정규화 후에도 플래너가 name/item_name 만 넘기는 경우가 있어 searchTerm 으로 맞춘다.
         if not (out.get("searchTerm") or out.get("search_term") or out.get("query")):
@@ -493,6 +545,86 @@ def _normalize_mcp_arguments(
         if y is not None:
             b["y"] = _as_int(y)
         return b
+
+    # ── Weapons.json ──
+    if target_file == "Weapons.json" and action == "create":
+        if "name" not in out and "weapon_name" in out:
+            out["name"] = out.pop("weapon_name")
+        return out
+
+    if target_file == "Weapons.json" and action == "update":
+        wid = out.get("weaponId", out.get("weapon_id"))
+        updates = out.get("updates")
+        built = {}
+        if wid is not None:
+            built["weaponId"] = _as_int(wid)
+        if isinstance(updates, dict):
+            built["updates"] = updates
+        return built
+
+    # ── Armors.json ──
+    if target_file == "Armors.json" and action == "create":
+        if "name" not in out and "armor_name" in out:
+            out["name"] = out.pop("armor_name")
+        return out
+
+    if target_file == "Armors.json" and action == "update":
+        aid = out.get("armorId", out.get("armor_id"))
+        updates = out.get("updates")
+        built = {}
+        if aid is not None:
+            built["armorId"] = _as_int(aid)
+        if isinstance(updates, dict):
+            built["updates"] = updates
+        return built
+
+    # ── Classes.json ──
+    if target_file == "Classes.json" and action == "create":
+        if "name" not in out and "class_name" in out:
+            out["name"] = out.pop("class_name")
+        return out
+
+    if target_file == "Classes.json" and action == "update":
+        cid = out.get("classId", out.get("class_id"))
+        updates = out.get("updates")
+        built = {}
+        if cid is not None:
+            built["classId"] = _as_int(cid)
+        if isinstance(updates, dict):
+            built["updates"] = updates
+        return built
+
+    # ── States.json ──
+    if target_file == "States.json" and action == "create":
+        if "name" not in out and "state_name" in out:
+            out["name"] = out.pop("state_name")
+        return out
+
+    if target_file == "States.json" and action == "update":
+        sid_val = out.get("stateId", out.get("state_id"))
+        updates = out.get("updates")
+        built = {}
+        if sid_val is not None:
+            built["stateId"] = _as_int(sid_val)
+        if isinstance(updates, dict):
+            built["updates"] = updates
+        return built
+
+    # ── Enemies.json ──
+    if target_file == "Enemies.json" and action == "create":
+        if "name" not in out and "enemy_name" in out:
+            out["name"] = out.pop("enemy_name")
+        return out
+
+    if target_file == "Enemies.json" and action == "update":
+        eid = out.get("enemyId", out.get("enemy_id"))
+        updates = out.get("updates")
+        built = {}
+        if eid is not None:
+            built["enemyId"] = _as_int(eid)
+        if isinstance(updates, dict):
+            built["updates"] = updates
+        return built
 
     # list / query(get_system 등 인자 없음) / get_game_title / get_variables / get_switches
     if action in ("list", "query", "get_game_title", "list_variables", "list_switches"):
@@ -2135,6 +2267,30 @@ def _sanitize_mz_item_effects_for_schema(effects: Any) -> list[dict[str, Any]]:
     return out
 
 
+def _apply_mz_item_required_defaults(payload: dict[str, Any]) -> None:
+    """Planner/LLM이 Item 필수 필드를 빼거나 null로 넣는 경우를 보정한다.
+
+    setdefault만으로는 부족함: target_info에 ``occasion: null``이 있으면 키가 존재해 기본값이 안 들어감.
+    """
+    int_defaults: dict[str, int] = {
+        "occasion": 0,
+        "scope": 7,
+        "speed": 0,
+        "successRate": 100,
+        "repeats": 1,
+        "tpGain": 0,
+        "hitType": 0,
+        "animationId": -1,
+    }
+    for key, default in int_defaults.items():
+        cur = payload.get(key)
+        if cur is None:
+            payload[key] = default
+            continue
+        if isinstance(cur, str) and cur.strip() == "":
+            payload[key] = default
+
+
 def _structured_create_item_sync(data_path: Path, target_info: dict[str, Any]) -> dict[str, Any]:
     """구조화 플랜의 target_info로 Items.json 슬롯에 아이템을 기록한다 (MCP create_item 미노출 대응)."""
     from agent.schemas.items import Item
@@ -2199,7 +2355,8 @@ def _structured_create_item_sync(data_path: Path, target_info: dict[str, Any]) -
         arr.append(None)
 
     existing = arr[item_id]
-    new_name = str(target_info.get("name") or "").strip()
+    # Planner는 표시명을 item_name으로만 넘기는 경우가 있음(name 키 없음).
+    new_name = str(target_info.get("name") or target_info.get("item_name") or "").strip()
     if existing is not None and isinstance(existing, dict):
         ex_name = str(existing.get("name") or "").strip()
         if ex_name and new_name and ex_name != new_name:
@@ -2242,6 +2399,8 @@ def _structured_create_item_sync(data_path: Path, target_info: dict[str, Any]) -
             d.setdefault("variance", 20)
 
     payload.setdefault("effects", [])
+
+    _apply_mz_item_required_defaults(payload)
 
     try:
         model = Item.model_validate(payload)

--- a/agent/mcp_toolbox.py
+++ b/agent/mcp_toolbox.py
@@ -301,6 +301,13 @@ async def call_mcp_tool(
         }
 
     safe_args = dict(arguments)
+    # 통합 MCP(integration_MCP 등)는 툴마다 `projectPath`(게임 루트) 필수.
+    # 기존 k4zuki 계열은 `targetDir`(data/) 등 다른 키를 쓰기도 해 둘 다 채운다.
+    if "projectPath" not in safe_args:
+        safe_args["projectPath"] = str(game_root)
+    pk = (path_arg_name or os.environ.get("MCP_PATH_ARG_NAME", "targetDir")).strip()
+    if pk and pk not in safe_args:
+        safe_args[pk] = str(game_data_path.resolve())
 
     # per-call 타임아웃: 응답 지연 시 전체 워크플로우가 장시간 블로킹되는 것을 방지한다.
     timeout = float(os.environ.get("MCP_TIMEOUT", "30"))

--- a/agent/tests/check_mcp_smoke.py
+++ b/agent/tests/check_mcp_smoke.py
@@ -31,8 +31,8 @@ async def _main() -> int:
     game_id = os.environ.get("GAME_ID", "game_001")
     data_path: Path = resolve_game_data_path(game_id)
 
-    # k4zuki 서버 list_tools 기준: create_actor(name 필수)
-    # targetDir(또는 MCP_PATH_ARG_NAME)에 data_path를 주입하는 건 call_mcp_tool이 처리.
+    # 통합 MCP(integration_MCP) 기준: create_actor(name 필수)
+    # tool-registry.json의 canonical 이름 사용 (add_actor는 별칭)
     result = await call_mcp_tool(
         tool_name="create_actor",
         arguments={"name": "ZZZ_MCP_SMOKE_ACTOR"},

--- a/agent/tests/test_executor_mvp.py
+++ b/agent/tests/test_executor_mvp.py
@@ -1364,6 +1364,46 @@ def test_create_item_sync_default_damage(tmp_path):
     assert arr[1]["damage"]["formula"] == "0"
 
 
+def test_create_item_sync_planner_omits_occasion_like_fields(tmp_path):
+    """Planner가 Definition 대비 occasion 등 필수 필드를 빼도(또는 null) 성공해야 한다."""
+    import json as _json
+
+    executor_module = importlib.import_module("agent.graph.nodes.executor")
+    dp = tmp_path / "data"
+    _make_items_json(dp, [None, None, None])
+    info = {
+        "item_id": 3,
+        "item_name": "소화기",
+        "description": "화재 진압용 소화기",
+        "iconIndex": 1,
+        "price": 0,
+        "itypeId": 1,
+        "consumable": True,
+        "scope": 7,
+        "speed": 0,
+        "successRate": 100,
+        "repeats": 1,
+        "tpGain": 0,
+        "hitType": 0,
+        "animationId": -1,
+        "damage": {
+            "type": 0,
+            "elementId": -1,
+            "formula": "",
+            "variance": 0,
+            "critical": False,
+        },
+        "effects": [],
+        "note": "",
+        "occasion": None,
+    }
+    r = executor_module._structured_create_item_sync(dp, info)
+    assert r["success"] is True, r.get("stderr")
+    arr = _json.loads((dp / "Items.json").read_text(encoding="utf-8"))
+    assert arr[3]["name"] == "소화기"
+    assert arr[3]["occasion"] == 0
+
+
 def test_create_item_sync_effects_sanitized(tmp_path):
     """code=11, value1=500, value2=0 → swap 적용 확인."""
     import json as _json

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,11 +8,7 @@ services:
       context: .
       dockerfile: docker/backend.Dockerfile
       args:
-        # 다중 MCP 리포 URL (비워두면 해당 키는 빌드 스킵)
-        MCP_REPO_DEFAULT: ${MCP_REPO_DEFAULT:-https://github.com/k4zuki0539/-rpgmaker-mz-mcp.git}
-        MCP_REPO_MAKER: ${MCP_REPO_MAKER:-}
-        MCP_REPO_LOWER: ${MCP_REPO_LOWER:-}
-        MCP_REPO_UNDERSCORE: ${MCP_REPO_UNDERSCORE:-}
+        MCP_REPO: ${MCP_REPO:-https://github.com/rein1225/RPGMakerMZ_MCP.git}
     ports:
       - "8000:8000"  # EC2에서 외부 접근 허용
     env_file: .env.production

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -4,43 +4,23 @@
 # 빌드 컨텍스트: 프로젝트 루트 (Re-Verse/)
 
 # ------------------------------------------------------------
-# Stage 1: RPG Maker MZ MCP 서버 빌드 (Node)
+# Stage 1: 통합 RPG Maker MZ MCP 서버 빌드 (Node)
 # - stdio MCP는 백엔드 컨테이너 내부에 실행파일이 있어야 함
-# - 4개 MCP를 각각 clone + build 후 /mcp/<key> 로 모은다.
+# - 단일 리포를 clone + build 후 /mcp/default 로 복사한다.
 # ------------------------------------------------------------
 FROM node:20-alpine AS mcp-builder
 WORKDIR /mcp
 RUN apk add --no-cache git bash
 
-# 기본값은 현재 운영 중인 리포 1개만 지정.
-# 나머지 3개는 docker-compose.prod.yml 또는 CI ENV_FILE에서 URL을 주입.
-ARG MCP_REPO_DEFAULT=https://github.com/k4zuki0539/-rpgmaker-mz-mcp.git
-ARG MCP_REPO_MAKER=
-ARG MCP_REPO_LOWER=
-ARG MCP_REPO_UNDERSCORE=
+ARG MCP_REPO=https://github.com/rein1225/RPGMakerMZ_MCP.git
 
 RUN --mount=type=cache,target=/root/.npm \
     set -eux; \
-    mkdir -p /mcp/default /mcp/mcp_maker /mcp/rpgmaker_lower /mcp/rpgmaker_underscore; \
-    build_one() { \
-      key="$1"; \
-      url="$2"; \
-      if [ -z "$url" ]; then \
-        echo "skip $key (repo url empty)"; \
-        return 0; \
-      fi; \
-      work="/tmp/src-$key"; \
-      rm -rf "$work"; \
-      git clone --depth 1 "$url" "$work"; \
-      cd "$work"; \
-      if [ -f package-lock.json ]; then npm ci; else npm install; fi; \
-      npm run build; \
-      cp -R "$work"/. "/mcp/$key/"; \
-    }; \
-    build_one default "$MCP_REPO_DEFAULT"; \
-    build_one mcp_maker "$MCP_REPO_MAKER"; \
-    build_one rpgmaker_lower "$MCP_REPO_LOWER"; \
-    build_one rpgmaker_underscore "$MCP_REPO_UNDERSCORE"
+    git clone --depth 1 "$MCP_REPO" /tmp/src-mcp; \
+    cd /tmp/src-mcp; \
+    if [ -f package-lock.json ]; then npm ci; else npm install; fi; \
+    npm run build; \
+    cp -R /tmp/src-mcp/. /mcp/default/
 
 FROM python:3.12-slim
 


### PR DESCRIPTION
- Executor: MCP_TOOL_MAP을 integration_MCP 기준으로 정리 (create_actor/skill/item, Weapons·Armors·Classes·States·Enemies용 list/create/update)
- Items.json 직접 생성(_structured_create_item_sync): occasion 등 필수 필드 누락·null 보정, item_name으로 표시명 처리
- _normalize_mcp_arguments: Items create 및 DB별 create/update 키 보정
- search_enemies 보강용 로컬 검색·exists 연동
- mcp_toolbox: projectPath·targetDir 주입 유지
- Docker/compose·env 예시: 단일 MCP 빌드·경로 변수 정리
- 테스트: 아이템 생성 엣지 케이스, 스모크에서 canonical 툴명(create_actor)