### PR TITLE
fix: base docker-compose env_file을 .env.production으로 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: docker/backend.Dockerfile
     ports:
       - "8000:8000"
-    env_file: .env.development
+    env_file: .env.production
     environment:
       - APP_ENV=development
       - ENVIRONMENT=development


### PR DESCRIPTION
prod override와 합쳐질 때 .env.development를 찾는 문제 해결