### PR TITLE
fix(generation): 게임 생성 이벤트 배치 및 전투/워프 버그 수정

### DIFF
--- a/agent/generation/compilers/event_compiler.py
+++ b/agent/generation/compilers/event_compiler.py
@@ -405,7 +405,7 @@ class EventCompiler:
             # on_win에서 이미 ON한 스위치와 중복이면 생략
             on_win_switches = {a.set_switch for a in event.on_win if a.set_switch}
             if event.battle_switch not in on_win_switches:
-                sw_id = self.switch_table.switches[event.battle_switch]
+                sw_id = self.resolve_switch_id(event.battle_switch)
                 cmds.append(
                     {"code": 121, "indent": base_indent + 1, "parameters": [sw_id, sw_id, 0]}
                 )

--- a/agent/generation/mapgen/__init__.py
+++ b/agent/generation/mapgen/__init__.py
@@ -4,9 +4,10 @@ generate_map(spec) 호출 시 map_type에 맞는 생성기로 위임.
 """
 
 import logging
+from collections import deque
 
 from agent.generation.mapgen.dungeon_generator import generate_dungeon
-from agent.generation.mapgen.tile_checker import find_nearest_safe_coord, is_walkable
+from agent.generation.mapgen.tile_checker import is_walkable
 from agent.generation.mapgen.town_generator import generate_town
 from agent.generation.models import MapConnectionInfo, MapSpec
 
@@ -37,43 +38,87 @@ def generate_map(spec: MapSpec, seed: int = 0) -> list[int]:
 logger = logging.getLogger(__name__)
 
 
+def _find_largest_component(
+    data: list[int],
+    width: int,
+    height: int,
+    tileset_id: int,
+    tilesets: list | None = None,
+) -> list[tuple[int, int]]:
+    """맵 내 walkable 타일을 flood-fill로 연결 구역으로 분리하고 가장 큰 구역을 반환.
+
+    샘플 맵은 물/벽으로 분리된 복수의 독립 구역을 가질 수 있다.
+    가장 큰 연결 구역 = 플레이어가 실제로 이동하는 주요 구역.
+    """
+    all_walkable: set[tuple[int, int]] = set()
+    for y in range(height):
+        for x in range(width):
+            if is_walkable(data, x, y, width, height, tileset_id, tilesets):
+                all_walkable.add((x, y))
+
+    if not all_walkable:
+        return []
+
+    visited: set[tuple[int, int]] = set()
+    largest: list[tuple[int, int]] = []
+
+    for start in all_walkable:
+        if start in visited:
+            continue
+        component: list[tuple[int, int]] = []
+        queue: deque[tuple[int, int]] = deque([start])
+        visited.add(start)
+        while queue:
+            cx, cy = queue.popleft()
+            component.append((cx, cy))
+            for dx, dy in [(0, 1), (0, -1), (1, 0), (-1, 0)]:
+                nb = (cx + dx, cy + dy)
+                if nb not in visited and nb in all_walkable:
+                    visited.add(nb)
+                    queue.append(nb)
+        if len(component) > len(largest):
+            largest = component
+
+    return largest
+
+
 def calculate_spawn_point(
     spec: MapSpec,
     data: list[int],
     tilesets: list | None = None,
 ) -> tuple[int, int]:
-    """walkable 타일 탐색. tilesets가 주어지면 flags를, 아니면 레이어5를 기준."""
+    """맵에서 가장 큰 연결 통행 구역의 중심에 가장 가까운 타일을 스폰 포인트로 반환.
+
+    기존 방식(맵 중앙 고정)은 물/벽으로 분리된 샘플 맵에서 고립 구역을
+    스폰 포인트로 잘못 선택하는 문제가 있었다.
+    가장 큰 연결 구역을 선택함으로써 실제 플레이 가능 영역에 이벤트가 배치된다.
+    """
     w, h = spec.width, spec.height
-    sx, sy = spec.spawn_point
+    center_x, center_y = w // 2, h // 2
 
-    # 시작점이 이미 walkable이면 즉시 반환
-    if is_walkable(data, sx, sy, w, h, spec.tileset_id, tilesets):
-        logger.info("Map '%s': 기존 시작 좌표 (%d, %d)를 사용합니다.", spec.name, sx, sy)
-        return sx, sy
+    largest = _find_largest_component(data, w, h, spec.tileset_id, tilesets)
 
-    # 보정 시작 로그
-    logger.info(
-        "Map '%s': 초기 시작 좌표 (%d, %d) 통행 불가 -> 안전한 좌표 탐색 시작", spec.name, sx, sy
-    )
-
-    # 안전한 좌표 탐색 (BFS)
-    nx, ny = find_nearest_safe_coord(data, sx, sy, w, h, spec.tileset_id, tilesets)
-
-    if (nx, ny) != (sx, sy):
-        logger.info(
-            "Map '%s': 안전한 시작 좌표 발견 (%d, %d). 좌표를 수정했습니다.",
-            spec.name,
-            nx,
-            ny,
+    if not largest:
+        logger.warning(
+            "Map '%s': walkable 타일 없음 → 맵 중앙 폴백 (%d, %d)", spec.name, center_x, center_y
         )
-        return nx, ny
+        return center_x, center_y
 
-    logger.warning("Map '%s': 안전한 좌표를 찾지 못했습니다. 초기값 유지.", spec.name)
-    return sx, sy
+    # 가장 큰 구역에서 맵 중심에 가장 가까운 타일 선택
+    best = min(largest, key=lambda p: abs(p[0] - center_x) + abs(p[1] - center_y))
+
+    logger.info(
+        "Map '%s': 최대 연결 구역(%d타일) 스폰 포인트 → (%d, %d)",
+        spec.name,
+        len(largest),
+        best[0],
+        best[1],
+    )
+    return best
 
 
 def get_exit_coords(direction: str, width: int, height: int) -> tuple[int, int]:
-    """방향 → 맵 테두리 출구 좌표."""
+    """방향 → 맵 테두리 출구 좌표 (walkable 검증 없는 기본값, 하위 호환용)."""
     mid_x = width // 2
     mid_y = height // 2
     return {
@@ -84,13 +129,83 @@ def get_exit_coords(direction: str, width: int, height: int) -> tuple[int, int]:
     }.get(direction, (mid_x, height - 2))
 
 
+def _get_exit_coords_in_component(
+    direction: str,
+    width: int,
+    height: int,
+    component: set[tuple[int, int]],
+) -> tuple[int, int]:
+    """방향별 경계에서 main_component 안의 타일 중 경계에 가장 가까운 좌표 반환.
+
+    출구는 플레이어가 실제로 이동하는 주요 구역(component) 안에 있어야 한다.
+    component에 해당 경계 근처 타일이 없으면 기본 중앙 좌표로 폴백.
+    """
+    mid_x = width // 2
+    mid_y = height // 2
+
+    if direction == "south":
+        # y가 클수록 남쪽 경계에 가까움, x는 mid_x에 가까울수록 우선
+        candidates = sorted(component, key=lambda p: (-(p[1]), abs(p[0] - mid_x)))
+    elif direction == "north":
+        candidates = sorted(component, key=lambda p: (p[1], abs(p[0] - mid_x)))
+    elif direction == "east":
+        candidates = sorted(component, key=lambda p: (-(p[0]), abs(p[1] - mid_y)))
+    elif direction == "west":
+        candidates = sorted(component, key=lambda p: (p[0], abs(p[1] - mid_y)))
+    else:
+        candidates = sorted(component, key=lambda p: (-(p[1]), abs(p[0] - mid_x)))
+
+    if candidates:
+        return candidates[0]
+
+    # 폴백: 기본 중앙 좌표
+    return get_exit_coords(direction, width, height)
+
+
 def extract_connection_info(
     spec: MapSpec, data: list[int], tilesets: list | None = None
 ) -> MapConnectionInfo:
-    """타일 생성 후 맵 연결 좌표 추출."""
+    """타일 생성 후 맵 연결 좌표 추출.
+
+    스폰 포인트와 출구 좌표 모두 가장 큰 연결 통행 구역 안에서 선택한다.
+    이를 통해 이벤트가 플레이어가 실제로 이동 가능한 영역에 배치된다.
+    """
+    w, h = spec.width, spec.height
+
+    # 가장 큰 연결 구역 한 번만 계산 (spawn + exit 모두 재사용)
+    largest = _find_largest_component(data, w, h, spec.tileset_id, tilesets)
+    component_set: set[tuple[int, int]] = set(largest)
+
+    # 스폰 포인트: 최대 연결 구역 중심 근접 타일
+    if largest:
+        center_x, center_y = w // 2, h // 2
+        spawn = min(largest, key=lambda p: abs(p[0] - center_x) + abs(p[1] - center_y))
+        logger.info(
+            "Map '%s': 최대 연결 구역(%d타일) 스폰 포인트 → (%d, %d)",
+            spec.name,
+            len(largest),
+            spawn[0],
+            spawn[1],
+        )
+    else:
+        spawn = (w // 2, h // 2)
+        logger.warning("Map '%s': walkable 타일 없음 → 맵 중앙 스폰 폴백", spec.name)
+
+    # 출구 좌표: 최대 연결 구역 안에서 방향별 경계에 가장 가까운 타일
     exit_tiles = []
     for exit_spec in spec.exits:
-        ex, ey = get_exit_coords(exit_spec.direction, spec.width, spec.height)
+        if component_set:
+            ex, ey = _get_exit_coords_in_component(exit_spec.direction, w, h, component_set)
+        else:
+            ex, ey = get_exit_coords(exit_spec.direction, w, h)
+
+        logger.info(
+            "Map '%s': exit %s → (%d, %d)",
+            spec.name,
+            exit_spec.direction,
+            ex,
+            ey,
+        )
         exit_tiles.append(
             {
                 "direction": exit_spec.direction,
@@ -100,8 +215,6 @@ def extract_connection_info(
             }
         )
 
-    # 타일셋 정보와 함께 스폰 포인트 계산
-    spawn = calculate_spawn_point(spec, data, tilesets=tilesets)
     entry_tiles = [{"from_spawn": True, "x": spawn[0], "y": spawn[1]}]
 
     return MapConnectionInfo(

--- a/agent/generation/nodes/event_planner.py
+++ b/agent/generation/nodes/event_planner.py
@@ -106,6 +106,8 @@ async def event_planner(state: GenerationState) -> dict:
         )
         # battle quest_chest quest_switch ↔ NPC set_switch 충돌 수정 (NPC 대화로 배틀 우회 방지)
         result = _fix_battle_quest_switch_collision(result, spec.map_id, switch_table)
+        # battle 이벤트 battle_switch ↔ NPC set_switch 충돌 수정 (보스 전투 우회 방지)
+        result = _fix_npc_battle_switch_collision(result, spec.map_id)
         # NpcEvent condition_switch 검증: 존재하지 않는 _defeated 스위치 자동 교체
         result = _fix_npc_defeated_conditions(result, switch_table, spec.map_id)
         # 이동 이벤트 코드 생성 (condition = acquisitions.chest_switch)
@@ -1311,6 +1313,36 @@ def _fix_battle_quest_switch_collision(
     return result
 
 
+def _fix_npc_battle_switch_collision(events: list, map_id: int) -> list:
+    """NpcEvent의 set_switch가 battle 이벤트의 battle_switch와 충돌하면 제거.
+
+    LLM이 보스 NPC에게 _defeated 스위치를 set_switch로 배정하면,
+    NPC 대화만으로 battle_switch가 ON되어 보스 전투 조건(sw=OFF)이 영구 실패한다.
+    """
+    battle_switches: set[str] = {
+        getattr(e, "battle_switch", None)
+        for e in events
+        if e.type == "battle" and getattr(e, "battle_switch", None)
+    } - {None}
+
+    if not battle_switches:
+        return events
+
+    result = []
+    for e in events:
+        if e.type == "npc" and getattr(e, "set_switch", None) in battle_switches:
+            logger.warning(
+                "Map%d NpcEvent '%s': set_switch '%s'가 battle 이벤트의 battle_switch와 충돌 "
+                "→ NPC set_switch 제거 (전투 없이 보스 격파 방지)",
+                map_id,
+                e.name,
+                e.set_switch,
+            )
+            e = e.model_copy(update={"set_switch": None})
+        result.append(e)
+    return result
+
+
 def _fix_npc_defeated_conditions(
     events: list,
     switch_table: SwitchTable,
@@ -1390,6 +1422,8 @@ def _build_move_events(
             tile_by_dest[dest_id] = (tile.get("x", 1), tile.get("y", 1))
 
     _fallback_hint = "아직 조건이 충족되지 않았습니다."
+    # map_id → MapSpec 빠른 조회 (목적지 spawn_point 계산용)
+    map_spec_by_id: dict[int, MapSpec] = {s.map_id: s for s in map_specs} if map_specs else {}
     events: list = []
 
     for move in screenplay.moves:
@@ -1424,6 +1458,14 @@ def _build_move_events(
 
         ex, ey = tile_xy
 
+        # 목적지 맵 spawn_point: 최대 연결 구역 기준으로 tile_generator가 교정한 값
+        # to_y=1 하드코딩 대신 사용하여 이동 불가 타일 도착 문제 방지
+        dest_spec = map_spec_by_id.get(dest_id)
+        if dest_spec:
+            dest_spawn_x, dest_spawn_y = dest_spec.spawn_point
+        else:
+            dest_spawn_x, dest_spawn_y = ex, 1
+
         if move.direction == "forward":
             if not chest_switches:
                 # acquisitions가 없을 때: NPC talked_switches를 게이트 조건으로 대체
@@ -1456,8 +1498,8 @@ def _build_move_events(
                             x=ex,
                             y=ey,
                             to_map=move.to_map_name,
-                            to_x=ex,
-                            to_y=1,
+                            to_x=dest_spawn_x,
+                            to_y=dest_spawn_y,
                             direction="retain",
                             keeper_character_name="People1",
                             keeper_character_index=6,
@@ -1480,8 +1522,8 @@ def _build_move_events(
                             x=ex,
                             y=ey,
                             to_map=move.to_map_name,
-                            to_x=ex,
-                            to_y=1,
+                            to_x=dest_spawn_x,
+                            to_y=dest_spawn_y,
                             character_name="!Crystal",
                             character_index=2,
                         )
@@ -1502,8 +1544,8 @@ def _build_move_events(
                     x=ex,
                     y=ey,
                     to_map=move.to_map_name,
-                    to_x=ex,
-                    to_y=1,
+                    to_x=dest_spawn_x,
+                    to_y=dest_spawn_y,
                     direction="retain",
                     keeper_character_name="People1",
                     keeper_character_index=6,
@@ -1515,12 +1557,7 @@ def _build_move_events(
             )
 
         elif move.direction == "backward":
-            # backward 목적지: 이전 맵의 하단(플레이어가 forward로 나간 위치 근처)
-            target_spec = None
-            if map_specs:
-                target_spec = next((s for s in map_specs if s.map_id == dest_id), None)
-            to_y_back = (target_spec.height - 2) if target_spec else max(ey, 2)
-            to_x_back = (target_spec.width // 2) if target_spec else ex
+            to_x_back, to_y_back = dest_spawn_x, dest_spawn_y
             events.append(
                 TransferEvent(
                     type="transfer",

--- a/agent/generation/nodes/integrator.py
+++ b/agent/generation/nodes/integrator.py
@@ -712,6 +712,7 @@ def translate_map_ids(
 
     # 리다이렉션할 기본 목적지 후보들 (ID 리스트)
     valid_ids = sorted(id_mapping.values())
+    valid_new_ids = set(id_mapping.values())  # event_compiler가 이미 할당한 새 ID 집합
     fallback_id = valid_ids[0]  # 기본값: 첫 번째 맵
 
     events = map_json.get("events", [])
@@ -729,8 +730,13 @@ def translate_map_ids(
                         # 1. 맵 ID 번역
                         old_map_id = params[1]
                         if old_map_id in id_mapping:
+                            # 샘플 맵 원본 ID → 게임 내 새 ID로 번역
                             params[1] = id_mapping[old_map_id]
+                        elif old_map_id in valid_new_ids:
+                            # event_compiler가 이미 새 ID를 사용한 경우 → 그대로 유지
+                            pass
                         else:
+                            # 진짜 존재하지 않는 맵 참조만 fallback
                             params[1] = fallback_id
                             logger.info(
                                 "후처리 리다이렉션: 존재하지 않는 맵 참조 %d를 유효한 맵 %d로 변경했습니다.",

--- a/agent/generation/nodes/story_planner.py
+++ b/agent/generation/nodes/story_planner.py
@@ -57,9 +57,11 @@ def _align_map_types_with_game_spec(map_specs: list[MapSpec], game_spec: GameSpe
             game_type = raw_type if raw_type in {"town", "dungeon"} else "dungeon"
         else:
             game_type = "dungeon"
-        # 첫 번째 맵은 항상 town
+        # 첫 번째 맵은 항상 town, 마지막 맵은 항상 boss
         if i == 0:
             game_type = "town"
+        elif i == len(sorted_specs) - 1:
+            game_type = "boss"
         if ms.map_type != game_type:
             logger.info(
                 "_align_map_types: map_id=%d '%s' 타입 보정 %s → %s",

--- a/agent/generation/nodes/tile_generator.py
+++ b/agent/generation/nodes/tile_generator.py
@@ -81,6 +81,7 @@ async def tile_generator(state: GenerationState) -> dict:
 
     map_tiles: dict[int, list[int]] = {}
     connection_info: dict[int, MapConnectionInfo] = {}
+    updated_map_specs: list[MapSpec] = []
 
     for spec, result in zip(map_specs, results):
         if isinstance(result, Exception):
@@ -89,12 +90,29 @@ async def tile_generator(state: GenerationState) -> dict:
             connection_info[spec.map_id] = MapConnectionInfo(
                 map_id=spec.map_id, exit_tiles=[], entry_tiles=[]
             )
+            updated_map_specs.append(spec)
         else:
             map_id, data, conn = result
             map_tiles[map_id] = data
             connection_info[map_id] = conn
+            # connection_info에서 계산된 실제 spawn_point를 spec에 반영
+            # (map_designer는 중앙 좌표로 초기화하므로, 최대 연결 구역 기준으로 교정)
+            if conn.entry_tiles:
+                actual_spawn = (conn.entry_tiles[0]["x"], conn.entry_tiles[0]["y"])
+                if actual_spawn != spec.spawn_point:
+                    logger.info(
+                        "tile_generator: Map '%s' spawn_point 교정 (%d,%d) → (%d,%d)",
+                        spec.name,
+                        spec.spawn_point[0],
+                        spec.spawn_point[1],
+                        actual_spawn[0],
+                        actual_spawn[1],
+                    )
+                    spec = spec.model_copy(update={"spawn_point": actual_spawn})
+            updated_map_specs.append(spec)
 
     logger.info("tile_generator 완료: %d개 맵 데이터 준비", len(map_tiles))
+    map_specs = updated_map_specs
 
     await publish_progress(
         gen_id,
@@ -110,5 +128,6 @@ async def tile_generator(state: GenerationState) -> dict:
     return {
         "map_tiles": map_tiles,
         "connection_info": connection_info,
+        "map_specs": map_specs,  # spawn_point 교정된 버전 전파
         "completed_phases": completed,
     }


### PR DESCRIPTION
## Summary
- 맵 중앙 고정 spawn_point로 인해 NPC/이벤트가 이동 불가 고립 구역에 배치되던 문제 수정
- 보스 NPC 대화만으로 전투를 건너뛰고 엔딩이 바로 실행되는 버그 수정
- 워프 이동 후 맵 끝에 갇혀 상하 이동이 불가한 문제 수정

## Changes

### fix(map): 이벤트 배치 기준 좌표를 최대 연결 구역 기반으로 수정
- `mapgen/__init__.py`: spawn_point를 맵 중앙 고정에서 최대 연결 구역(largest connected component) 중심 타일로 변경
- `mapgen/__init__.py`: exit_tile 좌표도 최대 연결 구역 내 경계 근접 타일로 선택
- `tile_generator.py`: 교정된 spawn_point를 map_specs에 반영하여 event_planner 등 하위 노드에 전파
- `integrator.py`: 워프 목적지가 유효한 새 ID인 경우 Map1 fallback 제거
- `story_planner.py`: 마지막 맵 타입을 boss로 강제하여 엔딩 이벤트 생성 보장

### fix(event): 보스 전투 우회 및 워프 목적지 이동 불가 버그 수정
- `event_compiler.py`: battle_switch 조회 시 resolve_switch_id() 사용 (스위치 정규화 누락 KeyError 수정)
- `event_planner.py`: NPC set_switch가 battle_switch와 충돌 시 NPC set_switch 제거 (보스 전투 우회 방지)
- `event_planner.py`: 워프 목적지를 `to_y=1` 하드코딩에서 목적지 맵 spawn_point로 변경

## Test plan
- [ ] 게임 생성 후 모든 맵에서 NPC/상자/전투 이벤트가 이동 가능한 구역에 배치되는지 확인
- [ ] 보스 NPC 대화 후 전투 이벤트가 정상 발동되는지 확인
- [ ] 워프로 다음 맵 이동 시 도착 위치에서 상하좌우 이동 가능한지 확인
- [ ] 귀환 워프로 이전 맵 이동 시 동일하게 확인
- [ ] 마지막 맵(보스 맵)에서 전투 후 엔딩 이벤트 정상 실행 확인