### PR TITLE
fix(tests): WebSocket 테스트 event loop 불일치로 인한 DB 커넥션 오류 수정

### DIFF
--- a/app/backend/tests/conftest.py
+++ b/app/backend/tests/conftest.py
@@ -1,4 +1,4 @@
-"""테스트 공통 fixtures — in-memory SQLite + TestClient + 인증 헬퍼."""
+"""테스트 공통 fixtures — file-based SQLite + TestClient + 인증 헬퍼."""
 
 import os
 
@@ -14,15 +14,21 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.pool import NullPool
 
 _test_storage = tempfile.mkdtemp(prefix="reverse_test_games_")
 _test_base = tempfile.mkdtemp(prefix="reverse_test_base_")
+
+# 파일 기반 임시 SQLite: event loop 간 커넥션 공유 문제를 방지한다.
+# (sync TestClient 내부에서 별도 event loop가 생성되어도 동일 DB 파일에 접근 가능)
+_TEST_DB_FD, _TEST_DB_PATH = tempfile.mkstemp(suffix=".db", prefix="reverse_test_")
+os.close(_TEST_DB_FD)
 
 with patch.dict(
     os.environ,
     {
         "JWT_SECRET_KEY": "test-secret-key-for-testing",
-        "DATABASE_URL": "sqlite+aiosqlite:///:memory:",
+        "DATABASE_URL": f"sqlite+aiosqlite:///{_TEST_DB_PATH}",
         "STORAGE_PATH": _test_storage,
         "BASE_GAME_PATH": _test_base,
     },
@@ -35,10 +41,13 @@ with patch.dict(
         from app.backend.models.game import Project
         from app.backend.models.user import User
 
-# 테스트용 in-memory DB
+# NullPool: 커넥션을 pool에 보관하지 않고 매번 새로 열고 닫는다.
+# sync TestClient(별도 event loop)에서 pytest event loop의 커넥션을 재사용하다
+# 발생하는 "no active connection" 오류를 방지한다.
 TEST_ENGINE = create_async_engine(
-    "sqlite+aiosqlite:///:memory:",
+    f"sqlite+aiosqlite:///{_TEST_DB_PATH}",
     connect_args={"check_same_thread": False},
+    poolclass=NullPool,
 )
 TestSessionLocal = async_sessionmaker(TEST_ENGINE, class_=AsyncSession, expire_on_commit=False)
 


### PR DESCRIPTION
## 문제
CI에서 `test_other_user_token_rejected` 테스트가 아래 오류로 실패
qlalchemy.exc.OperationalError: (sqlite3.OperationalError) no active connection

## 원인
sync `TestClient`는 내부적으로 `anyio`를 통해 **별도 event loop**를 생성한다.
`TEST_ENGINE`의 connection pool에는 pytest event loop에서 만든 `aiosqlite` 커넥션이 남아있는데,
WebSocket endpoint가 DB를 조회할 때 pool이 이 커넥션을 재사용하려 하면 event loop 불일치로 오류가 발생한다.

로컬에서 통과한 이유는 pool이 비어있는 타이밍에 TestClient가 실행되어 새 커넥션을 생성했기 때문으로,
CI 환경(라이브러리 버전, 테스트 순서 차이 등)에서는 pool에 커넥션이 남아있어 버그가 표면화되었다.

## 수정
`app/backend/tests/conftest.py`의 `TEST_ENGINE` 설정 변경

  | 항목 | Before | After |                                                                           
  |------|--------|-------|                                                                           
  | DB | `sqlite+aiosqlite:///:memory:` | 파일 기반 임시 SQLite |
  | Pool | 기본 pool | `NullPool` |

- **파일 기반 SQLite**: 어떤 event loop의 커넥션이든 동일한 DB 파일에 독립적으로 접근 가능
- **NullPool**: 커넥션을 pool에 보관하지 않아 event loop 간 커넥션 재사용 자체를 차단
  
  ## 테스트
- [x] `TestGenerationWebSocket::test_other_user_token_rejected` 통과 확인
- [x] 기존 337개 테스트 회귀 없음