### PR TITLE
fix(docker): DEBIAN_FRONTEND 미설정으로 인한 Docker 빌드 무한 대기 수정

### DIFF
--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -24,17 +24,21 @@ RUN --mount=type=cache,target=/root/.npm \
 
 FROM python:3.12-slim
 
+# debconf가 대화형 입력을 기다리지 않도록 설정
+# nodesource 설치 스크립트(setup_20.x)가 내부적으로 apt-get을 실행할 때도 적용됨
+ENV DEBIAN_FRONTEND=noninteractive
+
 WORKDIR /app
 
 # 시스템 의존성 설치 (DB 빌드 도구 및 MCP용 Node.js 포함)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y \
+    apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gcc \
     libpq-dev \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # MCP 빌드 산출물을 런타임 이미지에 포함 (컨테이너 내부 경로 기준)


### PR DESCRIPTION
## 문제
EC2 배포 시 Docker 빌드가 770번째 줄에서 15분 이상 멈추는 현상 발생

debconf: TERM is not set, so the dialog frontend is not usable.
debconf: unable to initialize frontend: Dialog
debconf: falling back to frontend: Noninteractive

## 원인
`DEBIAN_FRONTEND` 환경변수가 설정되지 않은 상태에서 `apt-get`이 실행되면 `debconf`가 대화형 입력을 기다리며 무한 대기 상태에 빠진다.
특히 nodesource 설치 스크립트(`setup_20.x | bash -`)가 내부적으로 `apt-get`을 실행하는 과정에서도 동일하게 발생한다.

## 수정
`docker/backend.Dockerfile` 변경 
- `FROM python:3.12-slim` 직후 `ENV DEBIAN_FRONTEND=noninteractive` 추가
- Dockerfile의 직접 `apt-get` 호출뿐 아니라 nodesource 스크립트 내부 호출에도 적용됨
- `apt-get install`에 `--no-install-recommends` 추가로 불필요한 패키지 설치 제거