### PR TITLE
fix(docker): MCP 오류 제거, executor_v2 경로로 전환

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,18 +29,8 @@
 # 로컬 분석 산출물
 build-analysis
 
-# MCP 컨텍스트: mcp-builder가 로컬 integration_MCP를 COPY해서 빌드하므로 소스는 실어야 함.
-# 단 로컬 산출물/테스트/자동화 등 런타임에 불필요한 것은 제외해 컨텍스트를 경량화한다.
-mcp/rpgmaker-mz-mcp/
-mcp/integration_MCP/node_modules
-mcp/integration_MCP/dist
-mcp/integration_MCP/generated
-mcp/integration_MCP/test_project
-mcp/integration_MCP/automation
-mcp/integration_MCP/vendor
-mcp/integration_MCP/docs
-mcp/integration_MCP/merger
-mcp/integration_MCP/**/*.test.*
+# MCP 로컬 작업 디렉토리 (현재 배포에서 MCP 비활성 — 빌드 컨텍스트에 불필요)
+mcp/
 
 # 로그·임시
 **/*.log

--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -1,0 +1,232 @@
+# 이번 세션 따라가기 가이드
+
+> 이 세션에서 우리가 뭘 했는지를, 배경지식 없이도 따라올 수 있게 단계별로 풀어쓴 글입니다.
+> 대화는 복잡했지만 핵심은 "Docker 빌드가 왜 깨졌고, 어떻게 고치기로 했는가" 하나입니다.
+
+---
+
+## 0. 큰 그림 한 줄
+
+**배포할 때 Docker 이미지 빌드가 실패하고 있었고, 원인은 "Dockerfile이 옛날 경로를 그대로 쓰고 있어서"였다. 그래서 Dockerfile을 최신 상태에 맞게 고쳤다.** 끝.
+
+나머지는 "왜 그렇게 고쳐야 하는지", "다른 방법은 없는지", "고치면서 뭘 망가뜨리진 않을지" 확인한 과정입니다.
+
+---
+
+## 1. 배경지식 (최소한만)
+
+이 세션을 이해하려면 아래 용어 5개만 알면 됩니다.
+
+### 1-1. Docker 이미지 / Dockerfile
+- **Docker 이미지**: 서버에서 돌릴 프로그램을 "통째로 묶어놓은 압축 파일" 같은 것. OS, 파이썬, 우리 코드까지 다 들어있음.
+- **Dockerfile**: 이 이미지를 "어떻게 만들지" 적어둔 레시피 파일. `docker build` 실행하면 이 레시피대로 이미지가 만들어짐.
+- **빌드(build)**: 레시피대로 이미지를 만드는 과정.
+- 우리 레포에선 `docker/backend.Dockerfile`이 그 레시피.
+
+### 1-2. 멀티스테이지 빌드
+- Dockerfile 하나 안에서 `FROM ...` 이 여러 번 나올 수 있음. 각각을 "스테이지"라고 부름.
+- 우리 Dockerfile은 2-스테이지:
+  - **스테이지 1 (mcp-builder)**: Node.js로 MCP 서버를 빌드
+  - **스테이지 2 (python:3.12-slim)**: 실제 백엔드 서버를 담는 최종 이미지. 스테이지 1의 결과물을 복사해옴.
+- 이번에 깨진 건 **스테이지 1**.
+
+### 1-3. MCP (Model Context Protocol)
+- LLM이 외부 도구를 호출할 때 쓰는 프로토콜.
+- 우리 프로젝트는 "RPG Maker MZ 게임 파일을 수정하는 도구들"을 MCP 서버로 제공함.
+- 이 MCP 서버가 Node.js로 만들어져 있어서, 백엔드 컨테이너 안에 **Node로 빌드해서 같이 담아야 함**. 그래서 스테이지 1이 필요한 거.
+
+### 1-4. `.dockerignore`
+- `git`의 `.gitignore`와 비슷. **Docker 빌드 컨텍스트에 어떤 파일을 올리지 않을지** 적는 파일.
+- 여기 적힌 경로는 Dockerfile에서 `COPY` 해도 안 복사됨.
+
+### 1-5. npm / postinstall
+- **npm**: Node의 패키지 관리자. `npm install` = 의존성 설치.
+- **postinstall 스크립트**: npm이 패키지 설치 직후 자동으로 실행하는 스크립트. 어떤 패키지는 이 단계에서 "네이티브 바이너리 컴파일"이나 "Chromium 다운로드" 같은 무거운 일을 함.
+- `--ignore-scripts` 옵션: 이 postinstall을 **실행 안 하고 그냥 파일만 설치**하게 함.
+
+---
+
+## 2. 문제: 뭐가 깨졌나
+
+사용자가 받은 에러는 이랬어요:
+
+```
+err: backend.Dockerfile:17
+err:   17 | >>> RUN --mount=type=cache,target=/root/.npm \
+err:   18 | >>>     set -eux; \
+err:   19 | >>>     git clone --depth 1 "$MCP_REPO" /tmp/src-mcp; \
+err:   20 | >>>     cd /tmp/src-mcp; \
+err:   21 | >>>     if [ -f package-lock.json ]; then npm ci; else npm install; fi; \
+err:   22 | >>>     npm run build; \
+err:   23 | >>>     cp -R /tmp/src-mcp/. /mcp/default/
+err: exit code: 1
+```
+
+해석:
+- Dockerfile 17~23줄의 `RUN` 명령이 **exit code 1**로 끝남. 즉 **어딘가에서 실패**.
+- 이 RUN 블록이 하는 일은:
+  1. GitHub에서 외부 MCP 리포(`rein1225/RPGMakerMZ_MCP`)를 **git clone**
+  2. `npm ci` 또는 `npm install`로 의존성 설치
+  3. `npm run build`로 TypeScript 컴파일
+  4. 결과물 복사
+
+어딘가에서 실패했지만 **구체적으로 어느 줄인지 에러 메시지만으론 안 나옴**. Docker는 RUN 블록 전체를 찍어줄 뿐.
+
+---
+
+## 3. 원인 찾기
+
+### 3-1. 왜 외부 리포를 clone하고 있지?
+
+확인해보니 우리 레포 안에 `mcp/integration_MCP/` 폴더가 이미 있었어요. 이건 팀이 여러 MCP를 하나로 합친 **통합본**. 즉:
+
+- **과거**: 외부 리포 `rein1225/RPGMakerMZ_MCP`를 가져다 썼음
+- **현재**: 그걸 포함해 여러 MCP를 레포 내부에 `integration_MCP`로 통합함
+- **근데 Dockerfile은 아직도 옛날 외부 리포를 clone하고 있었음** ← 이게 근본 원인
+
+### 3-2. 그런데 왜 이제야 깨졌나?
+
+외부 리포의 `package.json`을 확인해보니 의존성 두 개가 문제였습니다:
+
+1. **`robotjs`** (devDependency, 마우스/키보드 제어 라이브러리)
+   - 이건 **C++ 네이티브 모듈**이라 설치할 때 `node-gyp`로 컴파일해야 함.
+   - 컴파일하려면 `python3`, `make`, `g++`, X11 헤더 같은 OS 패키지 필요.
+   - 우리 Dockerfile 스테이지 1은 `node:20-alpine` 기반인데 `git bash`만 설치 → **컴파일 도구 없음** → 설치 단계에서 실패.
+
+2. **`puppeteer`** (dependency, headless Chrome 제어)
+   - 설치할 때 postinstall 스크립트가 **Chromium 브라우저(~170MB)를 다운로드**함.
+   - CI 환경에서 네트워크/용량 이슈로 종종 실패.
+
+둘 중 어느 쪽이든 실패하면 `set -eux`(한 줄이라도 실패하면 즉시 중단) 때문에 전체 RUN이 exit 1.
+
+**"왜 이제야"**: 아마 이전엔 외부 리포 상태가 좀 달랐거나, CI 환경이 바뀌었거나, 아니면 예전엔 "어떻게든" 통과됐을 수도. 어쨌든 **지금 시점에선 이 경로가 깨질 수밖에 없는 구조**였어요.
+
+---
+
+## 4. 해결 방향 정하기 (대안 비교)
+
+그냥 아무렇게나 고치면 안 되니까 **4가지 옵션**을 놓고 비교했습니다.
+
+| Option | 설명 | 판정 |
+|---|---|---|
+| 1 | git clone 유지, `--ignore-scripts`만 추가 | ❌ 옛 외부 소스를 계속 쓰게 되는 근본 문제 해결 안 됨 |
+| **2** | **외부 clone 제거 → 레포 내부 `mcp/integration_MCP` COPY + `--ignore-scripts`** | ✅ **채택** |
+| 3 | 빌드 산출물(`dist/`)을 레포에 커밋해서 npm 빌드 자체를 없앰 | ❌ 반쪽짜리(런타임에 `node_modules` 필요), 레포 관리 복잡 |
+| 4 | alpine에 빌드 도구 다 깔고 정식으로 robotjs 컴파일 | ❌ alpine에서 robotjs 컴파일은 악명 높게 불안정 |
+
+**Option 2 선택 이유**: 우리 실제 사용 흐름(통합본을 쓰고 싶음)과 맞고, 리스크가 가장 작음.
+
+---
+
+## 5. Option 2 실행 전 5가지 확인
+
+"갑자기 고쳤다가 또 깨지면" 곤란하니까, PR 올리기 전에 **5가지를 확인**했습니다.
+
+| # | 확인 항목 | 결과 |
+|---|---|---|
+| 1 | `mcp/integration_MCP/package-lock.json` 있나? | ✅ 있음 (결정적 빌드 가능) |
+| 2 | `.dockerignore`에 `mcp/` 차단 라인 있나? | 🚨 **있음!** → 고쳐야 함 |
+| 3 | 빌드에 필요한 파일(`tsconfig.build.json`, `scripts/build-tool-registry.mjs`) 다 있나? | ✅ 다 있음 |
+| 4 | `puppeteer`/`screenshot-desktop`을 런타임에 실제로 쓰나? | ⚠️ 일부 툴(`playtest`)에서 씀 — 이번 배포에선 안 불러진다는 전제 |
+| 5 | 로컬에서 `docker build` 돌려봤나? | ❌ 사용자가 직접 해야 함 |
+
+**#2가 특히 중요**: `.dockerignore`에 `mcp/`가 통째로 막혀있으면, Dockerfile에서 `COPY mcp/integration_MCP/` 해도 **빈 폴더가 복사**됨. 그러면 또 깨짐.
+
+**#4 한계**: `--ignore-scripts`로 Chromium을 설치 안 하니까, `playtest` 기능이 런타임에 호출되면 에러 남. 지금은 그 기능 안 쓰는 전제로 통과.
+
+---
+
+## 6. 부가 논의들
+
+### 6-1. revert 할까?
+사용자가 로컬 커밋 이력이 살짝 얽혀있어서 `git revert` 할까 고민했는데, **비추했어요**. 이유:
+- 얽힌 건 "커밋 이력"이 아니라 "브랜치 간 내용 동기화" 문제라 revert로 안 풀림
+- revert는 새 커밋을 쌓으니까 오히려 이력이 더 복잡해짐
+- 지금 로컬 변경은 다 "유효한 변경"이라 되돌릴 이유 없음
+
+### 6-2. Dockerfile 전면 리팩터?
+EC2 디스크 압박(overlay2 2.4GB) 얘기가 나왔을 때 "Dockerfile 다이어트 계획"도 검토했어요. 하지만:
+- 한 번에 너무 많이 바꾸면 **배포가 아예 안 될 리스크**
+- 이번 PR의 우선순위는 "CI/CD 통과 + 배포 성공"
+- 그래서 **이번엔 MCP 빌드 수정만**, 나머지 다이어트는 별도 PR로 미룸
+- 관련 메모는 `docs/todo/todolist-deploy.md`에 정리
+
+### 6-3. 빌드 캐시 자동 청소?
+"build 끝나고 캐시 자동 삭제" 코드 넣을 수 있냐는 질문에 대해:
+- Dockerfile 안에는 못 넣음 (캐시는 Docker 데몬 관리)
+- CI 스텝 / EC2 cron / 배포 스크립트 중 하나 추가
+- 결정은 나중에, 일단 `todolist-deploy.md`에 옵션 정리해둠
+
+### 6-4. `PUPPETEER_SKIP_DOWNLOAD=true`는 뭐?
+- puppeteer가 설치 중 Chromium 브라우저(~170MB)를 자동 다운로드하는 걸 막는 환경변수.
+- 이미 `--ignore-scripts`로 막고 있지만 **이중 안전장치 + 의도 전달** 용도.
+- 없어도 빌드는 되지만 두면 안전.
+
+---
+
+## 7. 최종 변경 내역
+
+커밋 1개로 들어간 파일 3개:
+
+### 7-1. `docker/backend.Dockerfile` (수정)
+- 외부 `git clone` 코드 제거
+- `COPY mcp/integration_MCP/` 로 변경
+- `npm ci --ignore-scripts` + `ENV PUPPETEER_SKIP_DOWNLOAD=true` 추가
+
+### 7-2. `.dockerignore` (수정)
+- `mcp/` 전체 차단 라인 제거
+- 대신 선별 제외:
+  - `mcp/rpgmaker-mz-mcp/` (레거시 산출물, 사용 안 함)
+  - `mcp/integration_MCP/node_modules` (로컬 설치물, 이미지에 들어가면 안 됨)
+  - `mcp/integration_MCP/dist`, `generated`, `test_project`, `automation`, `vendor`, `docs`, `merger`
+  - `**/*.test.*`
+
+### 7-3. `docs/todo/todolist-deploy.md` (신규)
+- **[기록] 섹션**: 이번에 왜 이렇게 고쳤는지, 어떤 대안을 기각했는지 메모
+- **빌드 캐시 자동 정리 섹션**: 후속 과제. A/B/C 옵션 비교만 적어둠
+
+---
+
+## 8. 다음 단계 (사용자가 할 일)
+
+1. **로컬에서 빌드 돌려보기** (가장 중요)
+   ```bash
+   docker build -f docker/backend.Dockerfile .
+   ```
+   성공하면 OK. 실패하면 그 에러 기반으로 추가 수정 필요.
+
+2. **커밋 & 푸시**
+   ```bash
+   git commit  # 이미 스테이지돼 있음. 메시지는 세션 중 작성한 초안 참고.
+   git push origin feat/etc
+   ```
+
+3. **develop 대상 PR 생성**
+   - PR 제목/본문 초안은 세션 마지막에 작성해둠
+   - develop CI(Backend/Frontend) 초록 확인
+   - develop → main 머지 → 배포 스텝 통과 확인
+
+---
+
+## 9. 용어 사전 (세션 중 나온 것)
+
+- **CI/CD**: Continuous Integration/Delivery. PR 올렸을 때 자동으로 테스트/빌드/배포 돌리는 파이프라인.
+- **build context**: `docker build` 실행할 때 Docker 데몬에 전송되는 파일 묶음. `.dockerignore`가 이 범위를 제한.
+- **스테이지**: Dockerfile 안의 `FROM ... AS name` 블록 하나.
+- **alpine**: 가벼운 리눅스 배포판. 이미지 크기는 작지만 기본 도구가 적음.
+- **slim**: Debian 기반의 경량 변종. alpine보단 크지만 호환성 좋음.
+- **native module (네이티브 모듈)**: npm 패키지 중 설치 시 C/C++ 컴파일이 필요한 것.
+- **node-gyp**: Node.js 네이티브 모듈을 컴파일하는 도구.
+- **headless Chrome**: GUI 없이 돌아가는 크롬. 자동화/테스트용.
+- **postinstall hook**: npm install 직후 자동 실행되는 스크립트.
+- **`set -eux`**: 쉘 옵션. `e`=에러 나면 중단, `u`=정의 안 된 변수 쓰면 에러, `x`=실행 명령 출력.
+- **overlay2**: Docker의 파일시스템 드라이버. 이미지 레이어를 여기에 쌓음.
+- **builder cache**: 빌드 중 중간 레이어 캐시. 빠른 재빌드용이지만 쌓이면 용량 먹음.
+
+---
+
+## 10. 한 줄 요약 (다시)
+
+**"외부 리포 clone 대신 레포 안의 통합본을 쓰도록 Dockerfile 고쳤고, 부수 효과로 `.dockerignore`랑 문서도 손봤다."**
+
+이게 전부입니다.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,8 @@ services:
       - APP_ENV=production
       - ENVIRONMENT=production
       - DEBUG=false
+      # MCP(Node stdio) 비활성 — executor_v2 dispatch로 처리. env_file을 덮어쓰기 위해 명시.
+      - MCP_ENABLED=false
       # STORAGE_BACKEND, DATABASE_URL, S3_* 는 EC2의 .env.production(또는 GitHub ENV_FILE)에서 주입 권장
     volumes: []  # 프로덕션에서는 볼륨 마운트 제거 (override)
     restart: unless-stopped

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -2,52 +2,30 @@
 # Re:Verse Backend - FastAPI, Python 3.12, uv
 # EC2에서 단독 실행용
 # 빌드 컨텍스트: 프로젝트 루트 (Re-Verse/)
-
-# ------------------------------------------------------------
-# Stage 1: 통합 RPG Maker MZ MCP 서버 빌드 (Node)
-# - stdio MCP는 백엔드 컨테이너 내부에 실행파일이 있어야 함
-# - 레포 내부 mcp/integration_MCP 소스를 COPY해 build 후 /mcp/default 로 복사한다.
-# - --ignore-scripts: robotjs gyp 컴파일, puppeteer Chromium 다운로드 등 postinstall 훅 차단
-#   (alpine에 build-base/X11 헤더 없어 robotjs 실패 + puppeteer는 런타임 playtest 미사용 전제)
-# ------------------------------------------------------------
-FROM node:20-alpine AS mcp-builder
-WORKDIR /src
-ENV PUPPETEER_SKIP_DOWNLOAD=true
-
-COPY mcp/integration_MCP/ /src/
-
-RUN --mount=type=cache,target=/root/.npm \
-    set -eux; \
-    if [ -f package-lock.json ]; then npm ci --ignore-scripts; else npm install --ignore-scripts; fi; \
-    npm run build; \
-    mkdir -p /mcp/default; \
-    cp -R /src/. /mcp/default/
+#
+# MCP(Node stdio 서버)는 현재 배포에서 비활성화. executor_v2 dispatch 경로로 처리.
+# - MCP 기능 복귀 시: mcp-builder 스테이지 + nodejs 설치 + MCP_NODE_SERVER_PATH를 복원하고
+#   `MCP_ENABLED=true` 를 주입한다.
 
 FROM python:3.12-slim
 
 # debconf가 대화형 입력을 기다리지 않도록 설정
-# nodesource 설치 스크립트(setup_20.x)가 내부적으로 apt-get을 실행할 때도 적용됨
 ENV DEBIAN_FRONTEND=noninteractive
+
+# MCP 비활성 기본값. docker-compose의 env_file/environment에서 재정의 가능하지만
+# 이미지 레벨 기본을 명시해 오작동(= MCP 호출 시 바이너리 없음) 가능성을 낮춘다.
+ENV MCP_ENABLED=false
 
 WORKDIR /app
 
-# 시스템 의존성 설치 (DB 빌드 도구 및 MCP용 Node.js 포함)
+# 시스템 의존성 설치 (DB 빌드 도구)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gcc \
     libpq-dev \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
-
-# MCP 빌드 산출물을 런타임 이미지에 포함 (컨테이너 내부 경로 기준)
-# - 다중 MCP 루트: /app/mcp/<key>
-# - 기존 단일 경로 호환: /app/mcp-server -> /app/mcp/default
-COPY --from=mcp-builder /mcp /app/mcp
-RUN ln -s /app/mcp/default /app/mcp-server
-ENV MCP_NODE_SERVER_PATH=/app/mcp-server/dist/index.js
 
 # uv 설치 (pip 캐시 마운트로 반복 빌드 가속)
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/docs/todo/todolist-deploy.md
+++ b/docs/todo/todolist-deploy.md
@@ -16,29 +16,48 @@
    - dependency `puppeteer` — postinstall이 Chromium ~170MB 다운로드 → CI 네트워크/용량 이슈로 실패 가능
    - `set -eux`라 둘 중 하나만 삐끗해도 exit 1
 
-### 선택한 해결 방식 (Option 2 - 로컬 COPY + ignore-scripts)
-- `git clone` 제거 → `COPY mcp/integration_MCP` 로 전환
-- `npm ci --ignore-scripts` + `PUPPETEER_SKIP_DOWNLOAD=true` 로 postinstall 훅 차단 (robotjs gyp 컴파일, puppeteer Chromium 다운로드 둘 다 스킵)
-- `.dockerignore`에서 `mcp/` 전체 제외 라인 조정 (기존엔 `mcp/` 전체 차단 → COPY가 빈 폴더 될 상태였음)
-- `DEBIAN_FRONTEND=noninteractive` 보존 (main의 2da02b7 커밋 내용 — develop에는 없어서 머지 시 유실 위험)
-- `uv sync` 2단계 분리(의존성/프로젝트) 포함 — 캐시 효율 ↑
+### 초기 선택(Option 2) → 실패 → 최종 선택(Path E)
+
+#### Option 2 (로컬 COPY + ignore-scripts) — ❌ CD 실행에서 실패
+- `git clone` 제거 → `COPY mcp/integration_MCP` 로 전환 시도
+- **실패 원인**: `mcp/integration_MCP/`가 Re-Verse 레포에 커밋되어 있지 않음 (nested git repo 상태, 사용자 로컬 파일시스템에만 존재). CD 러너는 체크아웃한 Re-Verse 레포만 가지고 빌드하므로 `COPY` 대상이 없어 `"/mcp/integration_MCP": not found` 에러 발생.
+- 추가 발견: `mcp/integration_MCP`의 `origin`이 Dockerfile이 clone하던 `rein1225/RPGMakerMZ_MCP`와 동일. 즉 "통합본"은 upstream의 포크 + 로컬 미커밋 수정본. 양쪽 원격 어디에도 push 안 된 상태였음.
+
+#### Path E (최종 채택) — MCP 스테이지 통째 제거 + executor_v2 경로로 운영
+- Dockerfile에서 `mcp-builder` 스테이지 전체 삭제
+- `COPY --from=mcp-builder`, `ln -s /app/mcp/default`, `ENV MCP_NODE_SERVER_PATH`, nodejs 설치 블록 모두 제거
+- Dockerfile에 `ENV MCP_ENABLED=false` 베이스라인 추가
+- `docker-compose.prod.yml`의 `environment:`에도 `MCP_ENABLED=false` 명시해 env_file 값을 override
+- `.dockerignore`의 `mcp/` 전체 차단 라인 복원 (빌드 컨텍스트에 불필요)
+- `DEBIAN_FRONTEND=noninteractive`, `uv sync` 2단계 분리 유지
+
+**작동 근거**:
+- `agent/graph/nodes/executor.py`는 `MCP_ENABLED=false`이면 자동으로 `executor_v2.dispatch`로 fallback
+- `agent/graph/nodes/executor_v2/`에 MCP 의존성 0건 (grep 확인)
+- 지원 파일: Actors, Classes, Skills, Items, Weapons, Armors, Enemies, States, System, Map### — RPG Maker 핵심 편집 범위 커버
+- pytest `test_mcp_toolbox.py`, `test_mcp_server_resolve.py`는 monkeypatch 기반 순수 단위 테스트 → MCP 바이너리 미호출로 CI 영향 없음
 
 ### 대안 검토와 기각 사유
-- **Option 1 (`--ignore-scripts`만 추가, git clone 유지)**: CI는 살지만 로컬 통합본 변경이 배포에 반영 안 됨. upstream 의존 계속 유지되는 문제.
-- **Option 3 (`dist/` 를 레포에 커밋)**: 런타임에 `node_modules` 필요해서 반쪽짜리. PR diff 노이즈 폭증.
-- **Option 4 (alpine에 빌드툴 설치, ignore-scripts 없이 풀 설치)**: robotjs alpine 빌드가 historically 불안정. CI 안정성 오히려 ↓.
+- **Option 1 (`--ignore-scripts`만 추가, git clone 유지)**: CI는 살지만 upstream엔 통합본 수정이 push 안 됨 → 런타임에 MCP 기능 대거 불일치 예상.
+- **Option 3 (`dist/` 를 레포에 커밋)**: 런타임 `node_modules` 필요해서 반쪽짜리.
+- **Option 4 (alpine에 빌드툴 설치)**: robotjs alpine 빌드 historically 불안정.
+- **Path B (로컬 수정을 upstream에 push 후 clone)**: upstream 레포 권한 이슈 + 타 레포 관리 오버헤드 → 이번 배포엔 부적합.
+- **Path C (integration_MCP를 Re-Verse에 통째 commit)**: 수천 파일 diff 폭증, 배포 스코프 초과.
 
 ### 알려진 한계 (배포 후 후속 조치 필요 시)
-- `--ignore-scripts`로 Chromium 미설치. MCP `playtest` 계열 tool (handlers/playtest.ts, utils/playtestHelpers.ts)은 런타임 호출 시 실패함. 현재는 prod에서 호출 안 되는 전제로 통과.
-- 이미지에 devDeps(typescript, tsx, vitest 등)도 같이 포함됨. 크기 최적화는 별도 PR로.
-- EC2 루트 디스크 압박(overlay2 2.4GB)은 이번 PR 범위 밖 — 아래 "빌드 캐시 자동 정리" 항목에서 별도 처리.
+- **MCP 전용 고급 기능**: Troops.json, CommonEvents.json, Animations.json, Tilesets.json 등 executor_v2 미지원 파일 호출 시 "지원하지 않는 target_file" 에러. 핵심 편집 플로우 아니면 영향 제한적.
+- MCP 기능 복귀하려면 (1) integration_MCP 소스를 레포에 committable 형태로 정리 → (2) Dockerfile mcp-builder 복원 → (3) `MCP_ENABLED=true`. 별도 PR로.
+- EC2 루트 디스크 압박(overlay2 2.4GB)은 이번 PR 범위 밖 — 아래 "빌드 캐시 자동 정리" 항목에서 별도 처리. **부수 효과: Path E로 이미지 크기 크게 감소(Node.js + MCP 산출물 제거)** — 디스크 압박 일부 자동 완화.
 
 ### 검증 체크리스트
-- [x] `mcp/integration_MCP/package-lock.json` 존재 확인
-- [x] `.dockerignore`의 `mcp/` 차단 라인 조정 필요 확인
-- [x] 빌드 필수 파일(`tsconfig.build.json`, `scripts/build-tool-registry.mjs`) 존재 확인
-- [x] puppeteer/screenshot-desktop 런타임 사용처 파악 (playtest 계열)
+- [x] executor_v2의 MCP 의존성 부재 확인 (`agent/graph/nodes/executor_v2/` grep)
+- [x] executor가 `MCP_ENABLED=false`에서 v2로 fallback함 확인 (`agent/mcp_toolbox.py:49`, `executor.py:1719`)
+- [x] executor_v2 지원 파일 범위 확인 (`handlers/entity.py:20` ALL_SUPPORTED)
+- [x] pytest MCP 관련 테스트가 바이너리 미호출 확인 (monkeypatch only)
+- [x] `.github/workflows/deploy.yml`이 단순 SSH + `docker compose up --build` 구조 확인 → 추가 수정 불필요
+- [x] `.github/workflows/ci.yml` pytest가 MCP 호출 안 함 확인
 - [ ] 로컬 `docker build -f docker/backend.Dockerfile .` 성공 (사용자 환경에서 확인)
+- [ ] EC2 `.env.production`에 `MCP_ENABLED=true`가 있는지 확인 후 필요 시 제거/false로 변경 (compose env로 override되지만 명시적 정리 권장)
 
 ---
 


### PR DESCRIPTION
나중에 배포할때 완전 바꿔야하지만!!!
executor_v2로 전환해서 mcp 사용없이 올립니다(제발)