### PR TITLE
fix: 게임 생성 파일 I/O 이벤트 루프 블로킹 해제 및 S3 업로드 후 로컬 정리

### DIFF
--- a/agent/generation/writer.py
+++ b/agent/generation/writer.py
@@ -25,7 +25,7 @@ def _atomic_write_json(dest: Path, content: dict) -> None:
         raise
 
 
-async def write_project_to_disk(game_id: str, final_project: dict) -> None:
+def write_project_to_disk(game_id: str, final_project: dict) -> None:
     """final_project dict → storage/games/{game_id}/data/ JSON 파일 저장."""
     data_path: Path = get_game_data_path(game_id)
     data_path.mkdir(parents=True, exist_ok=True)

--- a/app/backend/api/v1/endpoints/generation.py
+++ b/app/backend/api/v1/endpoints/generation.py
@@ -7,6 +7,7 @@ canonical: docs/The_world/IMPLEMENTATION_GUIDE.md §8
 import asyncio
 import gc
 import logging
+import shutil
 import time
 from collections import deque
 from uuid import uuid4
@@ -208,11 +209,15 @@ async def _run_generation_core(
         if final_state.get("final_project"):
             from agent.generation.writer import write_project_to_disk
 
-            await write_project_to_disk(game_id, final_state["final_project"])
+            await asyncio.to_thread(write_project_to_disk, game_id, final_state["final_project"])
             if settings.STORAGE_BACKEND == "s3":
+                from app.backend.core.game_paths import get_game_root
                 from app.backend.services.s3_game_storage import sync_game_to_s3
 
                 await asyncio.to_thread(sync_game_to_s3, game_id)
+                local_dir = get_game_root(game_id)
+                if local_dir.is_dir():
+                    await asyncio.to_thread(shutil.rmtree, local_dir)
 
         _generation_states[generation_id] = GenerationStatusResponse(
             generation_id=generation_id,


### PR DESCRIPTION
## 변경 사항
사용자 테스트 대비 동시 요청 증가에 앞서 서버 동시성 이슈를 선제적으로 수정합니다.

### 문제
`write_project_to_disk`가 `async def`로 선언되어 있었지만 내부에서 `await` 없이 동기 파일 I/O를 실행하고 있었음.
이벤트 루프에서 직접 `await`로 호출되어 파일 쓰기 중 다른 요청을 처리하지 못하는 상태.

### 수정
- `write_project_to_disk`: `async def` → `def` 복원
- 호출부를 `await asyncio.to_thread(write_project_to_disk, ...)` 로 변경 → 스레드 풀에서 실행
- S3 업로드 완료 후 로컬 게임 디렉토리 삭제 추가 (`S3` 환경만 적용)

### 영향 범위
- `agent/generation/writer.py`
- `app/backend/api/v1/endpoints/generation.py`
- 로컬 개발 환경(`STORAGE_BACKEND=local`)에는 영향 없음