### PR TITLE
fix: 배포 환경 대기열/진행률 polling 대응 + S3 파일 서빙 수정

### DIFF
--- a/agent/generation/writer.py
+++ b/agent/generation/writer.py
@@ -25,7 +25,7 @@ def _atomic_write_json(dest: Path, content: dict) -> None:
         raise
 
 
-async def write_project_to_disk(game_id: str, final_project: dict) -> None:
+def write_project_to_disk(game_id: str, final_project: dict) -> None:
     """final_project dict → storage/games/{game_id}/data/ JSON 파일 저장."""
     data_path: Path = get_game_data_path(game_id)
     data_path.mkdir(parents=True, exist_ok=True)

--- a/app/backend/api/v1/endpoints/generation.py
+++ b/app/backend/api/v1/endpoints/generation.py
@@ -376,7 +376,7 @@ async def generation_websocket(
         return
 
     await websocket.accept()
-    logger.info("WebSocket 연결: gen_id=%s user_id=%d", generation_id, user.id)
+    logger.info("WebSocket 연결: gen_id=%s user_id=%d", generation_id, verified_user_id)
 
     try:
         async for event in subscribe_generation_events(generation_id):

--- a/app/backend/api/v1/endpoints/generation.py
+++ b/app/backend/api/v1/endpoints/generation.py
@@ -7,6 +7,7 @@ canonical: docs/The_world/IMPLEMENTATION_GUIDE.md §8
 import asyncio
 import gc
 import logging
+import shutil
 import time
 from collections import deque
 from uuid import uuid4
@@ -92,10 +93,13 @@ def _on_progress(generation_id: str, event: dict) -> None:
         return
     progress = event.get("progress")
     phase = event.get("phase")
+    message = event.get("message") or event.get("summary")
     if progress is not None and progress > (state.progress or 0):
         state.progress = progress
     if phase:
         state.phase = phase
+    if message:
+        state.message = message
     completed = event.get("type") == "phase_complete"
     if completed and phase and phase not in (state.completed_phases or []):
         if state.completed_phases is None:
@@ -208,11 +212,15 @@ async def _run_generation_core(
         if final_state.get("final_project"):
             from agent.generation.writer import write_project_to_disk
 
-            await write_project_to_disk(game_id, final_state["final_project"])
+            await asyncio.to_thread(write_project_to_disk, game_id, final_state["final_project"])
             if settings.STORAGE_BACKEND == "s3":
+                from app.backend.core.game_paths import get_game_root
                 from app.backend.services.s3_game_storage import sync_game_to_s3
 
                 await asyncio.to_thread(sync_game_to_s3, game_id)
+                local_dir = get_game_root(game_id)
+                if local_dir.is_dir():
+                    await asyncio.to_thread(shutil.rmtree, local_dir)
 
         _generation_states[generation_id] = GenerationStatusResponse(
             generation_id=generation_id,
@@ -298,6 +306,14 @@ async def get_generation_status(
     state = _generation_states.get(generation_id)
     if state is None or _generation_owners.get(generation_id) != current_user.id:
         raise HTTPException(status_code=404, detail="생성 작업을 찾을 수 없습니다.")
+    # 대기열 위치 실시간 재계산
+    if state.status == "queued":
+        try:
+            pos = list(_generation_queue).index(generation_id) + 1
+            state.queue_position = pos
+            state.queue_wait_seconds = pos * _WAIT_PER_GENERATION
+        except ValueError:
+            pass
     return state
 
 
@@ -313,6 +329,14 @@ async def get_generation_status_by_project(
     state = _generation_states.get(generation_id)
     if state is None or _generation_owners.get(generation_id) != current_user.id:
         raise HTTPException(status_code=404, detail="활성 생성 작업이 없습니다.")
+    # 대기열 위치 실시간 재계산
+    if state.status == "queued":
+        try:
+            pos = list(_generation_queue).index(generation_id) + 1
+            state.queue_position = pos
+            state.queue_wait_seconds = pos * _WAIT_PER_GENERATION
+        except ValueError:
+            pass
     return state
 
 

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -181,17 +181,23 @@ async def serve_game_file(game_id: str, path: str):
     project_file = Path(settings.STORAGE_PATH).resolve() / game_id / path
     if project_file.is_file():
         return FileResponse(str(project_file))
-    # 2) base_game 공유 에셋 (img, js, css, audio 등)
+    # 2) data/ 요청이면 base_game fallback 건너뛰고 S3로 직행
+    #    (로컬 삭제 후 base_game 초기 데이터가 반환되는 문제 방지)
+    if settings.STORAGE_BACKEND == "s3" and path.startswith("data/"):
+        s3_prefix = settings.S3_PREFIX.strip("/")
+        s3_key = f"{s3_prefix}/{game_id}/{path}"
+        s3_url = (
+            f"https://{settings.S3_BUCKET_NAME}.s3.{settings.AWS_REGION}.amazonaws.com/{s3_key}"
+        )
+        return RedirectResponse(url=s3_url, status_code=302)
+    # 3) base_game 공유 에셋 (img, js, css, audio 등 — data/ 제외)
     base_file = Path(settings.BASE_GAME_PATH).resolve() / path
     if base_file.is_file():
         return FileResponse(str(base_file))
-    # 3) S3 redirect fallback (EC2에 base_game 없을 때)
+    # 4) S3 redirect fallback (EC2에 base_game 없을 때)
     if settings.STORAGE_BACKEND == "s3":
         s3_prefix = settings.S3_PREFIX.strip("/")
-        if path.startswith("data/"):
-            s3_key = f"{s3_prefix}/{game_id}/{path}"
-        else:
-            s3_key = f"{s3_prefix}/base_game/{path}"
+        s3_key = f"{s3_prefix}/base_game/{path}"
         s3_url = (
             f"https://{settings.S3_BUCKET_NAME}.s3.{settings.AWS_REGION}.amazonaws.com/{s3_key}"
         )

--- a/app/frontend/src/pages/Dashboard.jsx
+++ b/app/frontend/src/pages/Dashboard.jsx
@@ -45,7 +45,7 @@ export default function Dashboard() {
   const wsRef = useRef(null)
   const pollingRef = useRef(null)
   const WS_BASE = useRef(
-    (window.location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.host
+    import.meta.env.VITE_WS_URL || ((window.location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.host)
   ).current
 
   useEffect(() => {
@@ -60,7 +60,7 @@ export default function Dashboard() {
     if (pollingRef.current) { clearInterval(pollingRef.current); pollingRef.current = null }
   }
 
-  // polling: 완료 감지 전용 (progress는 WS로만 받음, 15초 간격)
+  // polling: 진행률 + 대기열 + 완료 감지 (WS 불가 시 fallback, 5초 간격)
   function startPolling(genId) {
     if (pollingRef.current) return
     pollingRef.current = setInterval(async () => {
@@ -69,7 +69,7 @@ export default function Dashboard() {
       if (['completed', 'completed_with_warnings', 'failed', 'cancelled'].includes(s)) {
         cleanupPolling()
       }
-    }, 15000)
+    }, 5000)
   }
 
   // WS 연결 (JWT 토큰 포함)

--- a/app/frontend/src/store/generationSlice.js
+++ b/app/frontend/src/store/generationSlice.js
@@ -148,13 +148,23 @@ const generationSlice = createSlice({
         if (!['completed', 'completed_with_warnings', 'failed'].includes(state.status)) {
           state.status = s.status
         }
-        // 서버 progress가 클라이언트보다 높을 때만 업데이트 (서버가 0을 반환해도 기존 값 유지)
+        // 서버 progress가 클라이언트보다 높을 때만 업데이트
         if (s.progress > state.progress) state.progress = s.progress
         if (s.completed_phases?.length && s.completed_phases.length >= state.completedPhases.length) state.completedPhases = s.completed_phases
         if (s.is_success != null) state.isSuccess = s.is_success
         if (s.final_message) state.finalMessage = s.final_message
         if (s.validation_errors?.length) state.validationErrors = s.validation_errors
         if (s.error_message) state.error = s.error_message
+        if (s.message) state.message = s.message
+        if (s.phase) state.currentPhase = s.phase
+        // 대기열 정보 갱신
+        if (s.queue_position != null) state.queuePosition = s.queue_position
+        if (s.queue_wait_seconds != null) state.queueWaitSeconds = s.queue_wait_seconds
+        // queued → in_progress 전환
+        if (state.status === 'in_progress' && state.queuePosition > 0) {
+          state.queuePosition = 0
+          state.queueWaitSeconds = 0
+        }
       })
       .addCase(fetchActiveGeneration.fulfilled, (state, action) => {
         const s = action.payload


### PR DESCRIPTION
## Summary                                                                
                                                                                                                                                                                                                                                              
  ### polling 기반 진행률 (Vercel 배포 대응)
  - WebSocket 가 안 되는 Vercel→EC2 환경에서 polling 5초 간격으로 모든 기능 동작                                                                                                                                                                                      
  - 서버 status 조회 시 대기열 위치 실시간 재계산                                                                                                                                                                                                             
  - _on_progress 콜백에 message 필드 저장 추가 (상세 진행 메시지)                                                                                                                                                                                             
  - generationSlice: polling 응답에서 message/phase/queuePosition 전부 갱신                                                                                                                                                                                   
  - queued → in_progress 자동 전환 (type=progress 수신 시)                                                                                                                                                                                                    
                                                                                                                                                                                                                                                              
  ### S3 파일 서빙 수정                                                                                                                                                                                                                                       
  - serve_game_file: data/ 요청 시 base_game fallback 건너뛰고 S3 redirect                                                                                                                                                                                    
  - 로컬 삭제 후 base_game 초기 데이터가 반환되던 문제 해결                                                                                                                                                                                                   
                                                                                                                                                                                                                                                              
  ### 파일 I/O 개선                                                                                                                                                                                                                                           
  - write_project_to_disk: async → sync + asyncio.to_thread (이벤트 루프 블로킹 해제)                                                                                                                                                                         
  - S3 업로드 후 로컬 폴더 삭제 (EC2 디스크 누적 방지)                                                                                                                                                                                                        
                                                                                                                                                                                                                                                              
  ## Test plan                                                                                                                                                                                                                                                
  - [x] 생성 시작 → 5초마다 진행률/메시지 갱신 확인                                                                                                                                                                                                           
  - [x] 동시 생성 → 대기열 순서 줄어드는지 확인                                                                                                                                                                                                               
  - [x] 새로고침 → 진행률 복구 확인                                                                                                                                                                                                                           
  - [x] 배포 환경에서 게임 데이터 조회 시 생성된 데이터 표시 (base_game 아님)           