### PR TITLE
feat: 공지사항 시스템 추가, 대화기록 버그 수정, 입력 제한

### DIFF
--- a/app/backend/api/v1/endpoints/notices.py
+++ b/app/backend/api/v1/endpoints/notices.py
@@ -1,0 +1,202 @@
+"""공지사항 & 패치노트 엔드포인트.
+
+공개 읽기 + 관리자 전용 쓰기.
+"""
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.backend.core.security import get_admin_user
+from app.backend.db.session import get_db
+from app.backend.models.notice import Announcement, PatchNote
+from app.backend.schemas.notice import (
+    AnnouncementCreate,
+    AnnouncementResponse,
+    AnnouncementUpdate,
+    LatestVersionResponse,
+    PatchNoteCreate,
+    PatchNoteResponse,
+    PatchNoteUpdate,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# ── 공개: 공지사항 ────────────────────────────────────
+
+
+@router.get("/announcements", response_model=list[AnnouncementResponse])
+async def list_announcements(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(
+        select(Announcement)
+        .where(Announcement.is_published.is_(True))
+        .order_by(Announcement.pinned.desc(), Announcement.date.desc())
+    )
+    return result.scalars().all()
+
+
+# ── 공개: 패치노트 ────────────────────────────────────
+
+
+@router.get("/patch-notes", response_model=list[PatchNoteResponse])
+async def list_patch_notes(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(
+        select(PatchNote).where(PatchNote.is_published.is_(True)).order_by(PatchNote.date.desc())
+    )
+    return result.scalars().all()
+
+
+@router.get("/latest-version", response_model=LatestVersionResponse)
+async def get_latest_version(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(
+        select(PatchNote.version)
+        .where(PatchNote.is_published.is_(True))
+        .order_by(PatchNote.date.desc())
+        .limit(1)
+    )
+    version = result.scalar_one_or_none()
+    return LatestVersionResponse(version=version)
+
+
+# ── 관리자: 공지사항 CRUD ─────────────────────────────
+
+
+@router.post("/announcements", response_model=AnnouncementResponse, status_code=201)
+async def create_announcement(
+    data: AnnouncementCreate,
+    db: AsyncSession = Depends(get_db),
+    _admin=Depends(get_admin_user),
+):
+    item = Announcement(
+        title=data.title,
+        content=data.content,
+        date=data.date,
+        pinned=data.pinned,
+    )
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+    logger.info("[Notices] 공지 생성 | id=%d, title=%s", item.id, item.title)
+    return item
+
+
+@router.put("/announcements/{item_id}", response_model=AnnouncementResponse)
+async def update_announcement(
+    item_id: int,
+    data: AnnouncementUpdate,
+    db: AsyncSession = Depends(get_db),
+    _admin=Depends(get_admin_user),
+):
+    item = await db.get(Announcement, item_id)
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="공지사항을 찾을 수 없습니다."
+        )
+    for key, val in data.model_dump(exclude_unset=True).items():
+        setattr(item, key, val)
+    await db.commit()
+    await db.refresh(item)
+    return item
+
+
+@router.delete("/announcements/{item_id}", status_code=204)
+async def delete_announcement(
+    item_id: int,
+    db: AsyncSession = Depends(get_db),
+    _admin=Depends(get_admin_user),
+):
+    item = await db.get(Announcement, item_id)
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="공지사항을 찾을 수 없습니다."
+        )
+    await db.delete(item)
+    await db.commit()
+
+
+# ── 관리자: 패치노트 CRUD ─────────────────────────────
+
+
+@router.post("/patch-notes", response_model=PatchNoteResponse, status_code=201)
+async def create_patch_note(
+    data: PatchNoteCreate,
+    db: AsyncSession = Depends(get_db),
+    _admin=Depends(get_admin_user),
+):
+    item = PatchNote(
+        version=data.version,
+        title=data.title,
+        date=data.date,
+        changes=json.dumps([c.model_dump() for c in data.changes], ensure_ascii=False),
+    )
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+    logger.info("[Notices] 패치노트 생성 | id=%d, version=%s", item.id, item.version)
+    return item
+
+
+@router.put("/patch-notes/{item_id}", response_model=PatchNoteResponse)
+async def update_patch_note(
+    item_id: int,
+    data: PatchNoteUpdate,
+    db: AsyncSession = Depends(get_db),
+    _admin=Depends(get_admin_user),
+):
+    item = await db.get(PatchNote, item_id)
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="패치노트를 찾을 수 없습니다."
+        )
+    updates = data.model_dump(exclude_unset=True)
+    if "changes" in updates and updates["changes"] is not None:
+        updates["changes"] = json.dumps(
+            [c if isinstance(c, dict) else c.model_dump() for c in updates["changes"]],
+            ensure_ascii=False,
+        )
+    for key, val in updates.items():
+        setattr(item, key, val)
+    await db.commit()
+    await db.refresh(item)
+    return item
+
+
+@router.delete("/patch-notes/{item_id}", status_code=204)
+async def delete_patch_note(
+    item_id: int,
+    db: AsyncSession = Depends(get_db),
+    _admin=Depends(get_admin_user),
+):
+    item = await db.get(PatchNote, item_id)
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="패치노트를 찾을 수 없습니다."
+        )
+    await db.delete(item)
+    await db.commit()
+
+
+# ── 관리자: 전체 목록 (비공개 포함) ───────────────────
+
+
+@router.get("/admin/announcements", response_model=list[AnnouncementResponse])
+async def admin_list_announcements(
+    db: AsyncSession = Depends(get_db),
+    _admin=Depends(get_admin_user),
+):
+    result = await db.execute(select(Announcement).order_by(Announcement.date.desc()))
+    return result.scalars().all()
+
+
+@router.get("/admin/patch-notes", response_model=list[PatchNoteResponse])
+async def admin_list_patch_notes(
+    db: AsyncSession = Depends(get_db),
+    _admin=Depends(get_admin_user),
+):
+    result = await db.execute(select(PatchNote).order_by(PatchNote.date.desc()))
+    return result.scalars().all()

--- a/app/backend/api/v1/router.py
+++ b/app/backend/api/v1/router.py
@@ -11,6 +11,7 @@ from app.backend.api.v1.endpoints import (
     games,
     generation,
     llm,
+    notices,
 )
 
 api_router = APIRouter()
@@ -19,6 +20,7 @@ api_router.include_router(games.router, prefix="/games", tags=["Games"])
 api_router.include_router(llm.router, prefix="/llm", tags=["LLM"])
 api_router.include_router(editor.router, prefix="/editor", tags=["Editor"])
 api_router.include_router(admin.router, prefix="/admin", tags=["Admin"])
+api_router.include_router(notices.router, prefix="/notices", tags=["Notices"])
 api_router.include_router(docs.router, prefix="/docs", tags=["Docs"])
 api_router.include_router(generation.router, prefix="/generate", tags=["Generation"])
 api_router.include_router(bug_report.router, prefix="/bug-report", tags=["BugReport"])

--- a/app/backend/db/session.py
+++ b/app/backend/db/session.py
@@ -60,6 +60,7 @@ def get_engine() -> AsyncEngine | None:
             cursor = dbapi_conn.cursor()
             cursor.execute("PRAGMA journal_mode=WAL")
             cursor.execute("PRAGMA busy_timeout=5000")
+            cursor.execute("PRAGMA foreign_keys=ON")
             cursor.close()
 
     logger.info("AsyncSQLAlchemy engine 초기화 완료")

--- a/app/backend/models/__init__.py
+++ b/app/backend/models/__init__.py
@@ -1,7 +1,8 @@
 """DB 모델 패키지 — Base.metadata에 모든 모델을 등록."""
 
 from app.backend.models.game import ConversationLog, Project
+from app.backend.models.notice import Announcement, PatchNote
 from app.backend.models.refresh_token import RefreshToken
 from app.backend.models.user import User
 
-__all__ = ["User", "Project", "ConversationLog", "RefreshToken"]
+__all__ = ["User", "Project", "ConversationLog", "RefreshToken", "Announcement", "PatchNote"]

--- a/app/backend/models/game.py
+++ b/app/backend/models/game.py
@@ -41,7 +41,7 @@ class ConversationLog(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     project_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("projects.id"), index=True, nullable=False
+        Integer, ForeignKey("projects.id", ondelete="CASCADE"), index=True, nullable=False
     )
     user_input: Mapped[str] = mapped_column(Text, nullable=False)
     agent_response: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/app/backend/models/notice.py
+++ b/app/backend/models/notice.py
@@ -1,0 +1,46 @@
+"""공지사항 & 패치노트 모델."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.backend.db.base import Base
+
+
+class Announcement(Base):
+    __tablename__ = "announcements"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    date: Mapped[str] = mapped_column(String(20), nullable=False)
+    pinned: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_published: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+
+class PatchNote(Base):
+    __tablename__ = "patch_notes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    version: Mapped[str] = mapped_column(String(20), nullable=False, unique=True)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    date: Mapped[str] = mapped_column(String(20), nullable=False)
+    changes: Mapped[str] = mapped_column(Text, nullable=False)  # JSON 문자열
+    is_published: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )

--- a/app/backend/schemas/llm.py
+++ b/app/backend/schemas/llm.py
@@ -15,7 +15,7 @@ class UserInputRequest(BaseModel):
     """사용자 입력 요청 (Frontend -> Backend)"""
 
     project_id: int = Field(..., description="프로젝트 DB ID")
-    message: str = Field(..., description="유저 입력 프롬프트", min_length=1, max_length=500)
+    message: str = Field(..., description="유저 입력 프롬프트", min_length=1, max_length=1000)
 
 
 # ==================== Agent Response ====================

--- a/app/backend/schemas/llm.py
+++ b/app/backend/schemas/llm.py
@@ -15,7 +15,7 @@ class UserInputRequest(BaseModel):
     """사용자 입력 요청 (Frontend -> Backend)"""
 
     project_id: int = Field(..., description="프로젝트 DB ID")
-    message: str = Field(..., description="유저 입력 프롬프트", min_length=1)
+    message: str = Field(..., description="유저 입력 프롬프트", min_length=1, max_length=500)
 
 
 # ==================== Agent Response ====================

--- a/app/backend/schemas/notice.py
+++ b/app/backend/schemas/notice.py
@@ -1,0 +1,83 @@
+"""공지사항 & 패치노트 스키마."""
+
+import json
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# ── 공지사항 ──────────────────────────────────────────
+
+
+class AnnouncementCreate(BaseModel):
+    title: str = Field(..., min_length=1, max_length=200)
+    content: str = Field(..., min_length=1)
+    date: str = Field(..., min_length=1)
+    pinned: bool = False
+
+
+class AnnouncementUpdate(BaseModel):
+    title: str | None = Field(None, max_length=200)
+    content: str | None = None
+    date: str | None = None
+    pinned: bool | None = None
+    is_published: bool | None = None
+
+
+class AnnouncementResponse(BaseModel):
+    id: int
+    title: str
+    content: str
+    date: str
+    pinned: bool
+    is_published: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ── 패치노트 ──────────────────────────────────────────
+
+
+class PatchNoteChange(BaseModel):
+    type: str  # 'new' | 'fix' | 'improve' | 'remove'
+    text: str
+
+
+class PatchNoteCreate(BaseModel):
+    version: str = Field(..., min_length=1, max_length=20)
+    title: str = Field(..., min_length=1, max_length=200)
+    date: str = Field(..., min_length=1)
+    changes: list[PatchNoteChange]
+
+
+class PatchNoteUpdate(BaseModel):
+    version: str | None = Field(None, max_length=20)
+    title: str | None = Field(None, max_length=200)
+    date: str | None = None
+    changes: list[PatchNoteChange] | None = None
+    is_published: bool | None = None
+
+
+class PatchNoteResponse(BaseModel):
+    id: int
+    version: str
+    title: str
+    date: str
+    changes: list[PatchNoteChange]
+    is_published: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("changes", mode="before")
+    @classmethod
+    def parse_changes_json(cls, v: str | list) -> list:
+        if isinstance(v, str):
+            return json.loads(v)
+        return v
+
+
+class LatestVersionResponse(BaseModel):
+    version: str | None

--- a/app/frontend/src/components/chat/ChatInterface.jsx
+++ b/app/frontend/src/components/chat/ChatInterface.jsx
@@ -1,33 +1,53 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import MessageList from './MessageList'
 import PromptInput from './PromptInput'
 import TypingIndicator from './TypingIndicator'
 import SuggestedPrompts from './SuggestedPrompts'
 import { sendPrompt } from '../../services/llmApi'
+import { authFetch } from '../../services/api'
 
 const MAX_STORED_MESSAGES = 50
 
 export default function ChatInterface({ projectId, onGameUpdate, isCollapsed, onToggleCollapse }) {
-  const [messages, setMessages] = useState(() => {
-    try {
-      const stored = localStorage.getItem(`chat_${projectId}`)
-      return stored ? JSON.parse(stored) : []
-    } catch {
-      return []
-    }
-  })
+  const [messages, setMessages] = useState([])
   const [isLoading, setIsLoading] = useState(false)
   const [draft, setDraft] = useState('')
+  const didFetchRef = useRef(null)
 
+  // projectId 변경 시 백엔드에서 대화 기록 fetch
   useEffect(() => {
+    if (!projectId) return
+    // localStorage 캐시로 즉시 표시 (깜빡임 방지)
     try {
       const stored = localStorage.getItem(`chat_${projectId}`)
-      setMessages(stored ? JSON.parse(stored) : [])
-    } catch {
-      setMessages([])
-    }
+      if (stored) setMessages(JSON.parse(stored))
+      else setMessages([])
+    } catch { setMessages([]) }
+
+    // 백엔드 API에서 실제 데이터 fetch → localStorage 덮어쓰기
+    if (didFetchRef.current === projectId) return
+    didFetchRef.current = projectId
+    authFetch(`/v1/llm/history/${projectId}?limit=50`)
+      .then(logs => {
+        if (!Array.isArray(logs) || logs.length === 0) {
+          // 백엔드에 기록 없으면 localStorage도 비움
+          setMessages([])
+          localStorage.removeItem(`chat_${projectId}`)
+          return
+        }
+        const restored = []
+        logs.reverse().forEach(log => {
+          restored.push({ id: log.id * 2, role: 'user', content: log.user_input })
+          if (log.agent_response) {
+            restored.push({ id: log.id * 2 + 1, role: 'assistant', content: log.agent_response, intent: log.intent })
+          }
+        })
+        setMessages(restored)
+      })
+      .catch(() => { /* localStorage 캐시 유지 */ })
   }, [projectId])
 
+  // messages 변경 시 localStorage 캐시 갱신
   useEffect(() => {
     try {
       localStorage.setItem(`chat_${projectId}`, JSON.stringify(messages.slice(-MAX_STORED_MESSAGES)))

--- a/app/frontend/src/components/chat/PromptInput.jsx
+++ b/app/frontend/src/components/chat/PromptInput.jsx
@@ -1,5 +1,7 @@
 import { useRef, useEffect } from 'react'
 
+const MAX_LENGTH = 500
+
 export default function PromptInput({ onSubmit, disabled, value, onChange }) {
   const textareaRef = useRef(null)
 
@@ -16,7 +18,7 @@ export default function PromptInput({ onSubmit, disabled, value, onChange }) {
   }, [value])
 
   function handleChange(e) {
-    onChange(e.target.value)
+    if (e.target.value.length <= MAX_LENGTH) onChange(e.target.value)
   }
 
   function handleSubmit(e) {
@@ -33,19 +35,28 @@ export default function PromptInput({ onSubmit, disabled, value, onChange }) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-end gap-2 p-3" style={{ borderTop: '1px solid var(--border)' }}>
-      <textarea ref={textareaRef} value={value} onChange={handleChange} onKeyDown={handleKeyDown}
-        placeholder="게임 요소를 설명하세요..." disabled={disabled} rows={1}
-        className="flex-1 px-3 py-2 rounded-lg text-sm resize-none overflow-hidden focus:outline-none disabled:opacity-50"
-        style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)', border: '1px solid var(--border)', minHeight: '40px', maxHeight: '150px' }}
-      />
-      <button type="submit" disabled={disabled || !value.trim()}
-        className="w-8 h-8 flex items-center justify-center rounded-lg flex-shrink-0 disabled:opacity-30 transition-opacity"
-        style={{ background: 'var(--accent)' }}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="white">
-          <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
-        </svg>
-      </button>
+    <form onSubmit={handleSubmit} className="p-3" style={{ borderTop: '1px solid var(--border)' }}>
+      <div className="flex items-end gap-2">
+        <textarea ref={textareaRef} value={value} onChange={handleChange} onKeyDown={handleKeyDown}
+          placeholder="게임 요소를 설명하세요..." disabled={disabled} rows={1}
+          className="flex-1 px-3 py-2 rounded-lg text-sm resize-none overflow-hidden focus:outline-none disabled:opacity-50"
+          style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)', border: '1px solid var(--border)', minHeight: '40px', maxHeight: '150px' }}
+        />
+        <button type="submit" disabled={disabled || !value.trim()}
+          className="w-8 h-8 flex items-center justify-center rounded-lg flex-shrink-0 disabled:opacity-30 transition-opacity"
+          style={{ background: 'var(--accent)' }}>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="white">
+            <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
+          </svg>
+        </button>
+      </div>
+      {value.length > 0 && (
+        <div className="text-right mt-1">
+          <span className="text-[10px] tabular-nums" style={{ color: value.length >= MAX_LENGTH ? 'var(--accent)' : 'var(--text-secondary)' }}>
+            {value.length}/{MAX_LENGTH}
+          </span>
+        </div>
+      )}
     </form>
   )
 }

--- a/app/frontend/src/components/common/NoticeModal.jsx
+++ b/app/frontend/src/components/common/NoticeModal.jsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react'
+
+const TYPE_BADGE = {
+  new:     { label: 'NEW',  bg: 'rgba(34,197,94,0.12)',   color: '#4ade80' },
+  fix:     { label: 'FIX',  bg: 'rgba(239,68,68,0.12)',   color: '#f87171' },
+  improve: { label: '개선', bg: 'rgba(234,179,8,0.12)',   color: '#facc15' },
+  remove:  { label: '제거', bg: 'rgba(142,142,147,0.12)', color: '#8e8e93' },
+}
+
+export default function NoticeModal({ onClose }) {
+  const [tab, setTab] = useState('patch')
+  const [patchNotes, setPatchNotes] = useState([])
+  const [announcements, setAnnouncements] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    function onKey(e) { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/v1/notices/patch-notes').then(r => r.ok ? r.json() : []),
+      fetch('/api/v1/notices/announcements').then(r => r.ok ? r.json() : []),
+      fetch('/api/v1/notices/latest-version').then(r => r.ok ? r.json() : null),
+    ]).then(([patches, announces, latest]) => {
+      setPatchNotes(patches)
+      setAnnouncements(announces)
+      if (latest?.version) {
+        localStorage.setItem('re-verse:seen-version', latest.version)
+      }
+    }).catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
+      <div className="relative rounded-xl w-[520px] max-h-[80vh] flex flex-col shadow-xl"
+        style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}>
+
+        {/* 헤더 + 탭 */}
+        <div className="flex-shrink-0 px-5 pt-5 pb-0">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-base font-semibold" style={{ color: 'var(--text-primary)' }}>소식</h3>
+            <button onClick={onClose} className="text-sm px-1" style={{ color: 'var(--text-secondary)' }}>✕</button>
+          </div>
+          <div className="flex gap-1" style={{ borderBottom: '1px solid var(--border)' }}>
+            {[['patch', '패치노트'], ['announce', '공지사항']].map(([key, label]) => (
+              <button key={key} onClick={() => setTab(key)}
+                className="px-3 py-2 text-xs font-medium relative"
+                style={{ color: tab === key ? 'var(--text-primary)' : 'var(--text-secondary)' }}>
+                {label}
+                {tab === key && (
+                  <span className="absolute bottom-0 left-0 right-0 h-0.5" style={{ background: 'var(--accent)' }} />
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 콘텐츠 */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {loading
+            ? <p className="text-xs text-center py-8" style={{ color: 'var(--text-secondary)' }}>로딩 중...</p>
+            : tab === 'patch'
+              ? <PatchTab items={patchNotes} />
+              : <AnnounceTab items={announcements} />
+          }
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function PatchTab({ items }) {
+  if (!items.length) return <p className="text-xs text-center py-8" style={{ color: 'var(--text-secondary)' }}>패치노트가 없습니다.</p>
+  return (
+    <div className="space-y-5">
+      {items.map((patch) => (
+        <div key={patch.id}>
+          <div className="flex items-baseline gap-2 mb-2">
+            <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{patch.version}</span>
+            <span className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>{patch.date}</span>
+          </div>
+          <p className="text-xs mb-2" style={{ color: 'var(--text-secondary)' }}>{patch.title}</p>
+          <div className="space-y-1.5">
+            {patch.changes.map((c, i) => {
+              const badge = TYPE_BADGE[c.type] || TYPE_BADGE.new
+              return (
+                <div key={i} className="flex items-start gap-2">
+                  <span className="flex-shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded mt-px"
+                    style={{ background: badge.bg, color: badge.color }}>
+                    {badge.label}
+                  </span>
+                  <span className="text-xs leading-relaxed" style={{ color: 'var(--text-primary)' }}>{c.text}</span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function AnnounceTab({ items }) {
+  if (!items.length) return <p className="text-xs text-center py-8" style={{ color: 'var(--text-secondary)' }}>공지사항이 없습니다.</p>
+  return (
+    <div className="space-y-4">
+      {items.map((item) => (
+        <div key={item.id} className="rounded-lg p-3" style={{ background: 'var(--bg-primary)', border: item.pinned ? '1px solid rgba(255,59,92,0.2)' : '1px solid var(--border)' }}>
+          <div className="flex items-center gap-2 mb-1.5">
+            {item.pinned && (
+              <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded"
+                style={{ background: 'rgba(255,59,92,0.12)', color: 'var(--accent)' }}>고정</span>
+            )}
+            <span className="text-xs font-medium" style={{ color: 'var(--text-primary)' }}>{item.title}</span>
+            <span className="text-[11px] ml-auto flex-shrink-0" style={{ color: 'var(--text-secondary)' }}>{item.date}</span>
+          </div>
+          <p className="text-xs leading-relaxed whitespace-pre-line" style={{ color: 'var(--text-secondary)' }}>{item.content}</p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/frontend/src/components/generation/GenerationResult.jsx
+++ b/app/frontend/src/components/generation/GenerationResult.jsx
@@ -38,7 +38,7 @@ export default function GenerationResult({ onRetry, onGoToEditor }) {
           style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}
         >
           <p className="text-xs font-semibold mb-2" style={{ color: 'var(--text-secondary)' }}>
-            완료된 단계 ({completedPhases.length}/9)
+            완료된 단계 ({completedPhases.length}/10)
           </p>
           <p className="text-xs" style={{ color: 'var(--text-primary)' }}>
             {completedPhases.join(' → ')}

--- a/app/frontend/src/components/layout/Header.jsx
+++ b/app/frontend/src/components/layout/Header.jsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate, Link } from 'react-router-dom'
 import { logoutUser } from '../../store/userSlice'
 import BugReportModal from '../common/BugReportModal'
+import NoticeModal from '../common/NoticeModal'
 
 export default function Header() {
   const dispatch = useDispatch()
@@ -10,6 +11,19 @@ export default function Header() {
   const { isAuthenticated, user } = useSelector((s) => s.user)
   const currentProject = useSelector((s) => s.game.currentProject)
   const [bugOpen, setBugOpen] = useState(false)
+  const [noticeOpen, setNoticeOpen] = useState(false)
+  const [hasNew, setHasNew] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/v1/notices/latest-version')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data?.version && data.version !== localStorage.getItem('re-verse:seen-version')) {
+          setHasNew(true)
+        }
+      })
+      .catch(() => {})
+  }, [])
 
   async function handleLogout() {
     await dispatch(logoutUser())
@@ -41,6 +55,10 @@ export default function Header() {
             {user?.isAdmin && (
               <Link to="/admin" className="text-xs px-2 py-1 rounded-md font-medium" style={{ background: 'var(--accent)', color: '#fff' }}>관리자</Link>
             )}
+            <button onClick={() => setNoticeOpen(true)} className="re-nav-link text-xs px-2.5 py-1 relative" style={{ color: 'var(--text-secondary)' }}>
+              공지
+              {hasNew && <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full" style={{ background: 'var(--accent)' }} />}
+            </button>
             <button onClick={() => setBugOpen(true)} className="re-nav-link text-xs px-2.5 py-1" style={{ color: 'var(--text-secondary)' }}>버그리포트</button>
             <Link to="/docs" className="re-nav-link text-xs px-2.5 py-1" style={{ color: 'var(--text-secondary)' }}>문서</Link>
             <Link to="/dashboard" className="re-nav-link text-xs px-2.5 py-1" style={{ color: 'var(--text-secondary)' }}>프로젝트</Link>
@@ -56,6 +74,7 @@ export default function Header() {
       </nav>
     </header>
     {bugOpen && <BugReportModal onClose={() => setBugOpen(false)} />}
+    {noticeOpen && <NoticeModal onClose={() => { setNoticeOpen(false); setHasNew(false) }} />}
     </>
   )
 }

--- a/app/frontend/src/pages/Admin.jsx
+++ b/app/frontend/src/pages/Admin.jsx
@@ -6,8 +6,9 @@ import {
   Tooltip, ResponsiveContainer, Legend,
 } from 'recharts'
 import * as adminApi from '../services/adminApi'
+import { authFetch } from '../services/api'
 
-const TABS = ['개요', '유저 트렌드', '사용량', '헬스']
+const TABS = ['개요', '유저 트렌드', '사용량', '헬스', '공지 관리']
 
 function StatCard({ label, value, sub }) {
   return (
@@ -251,6 +252,9 @@ export default function Admin() {
           </>
         )}
 
+        {/* 공지 관리 탭 */}
+        {tab === 4 && <NoticeManager />}
+
         {/* 헬스 탭 */}
         {tab === 3 && (
           healthLoading ? (
@@ -287,6 +291,209 @@ export default function Admin() {
           ) : null
         )}
       </main>
+    </div>
+  )
+}
+
+// ── 공지 관리 컴포넌트 ──────────────────────────────────────────
+
+const CHANGE_TYPES = ['new', 'fix', 'improve', 'remove']
+const CHANGE_LABEL = { new: 'NEW', fix: 'FIX', improve: '개선', remove: '제거' }
+
+const emptyAnnouncement = { title: '', content: '', date: new Date().toISOString().slice(0, 10), pinned: false }
+const emptyPatchNote = { version: '', title: '', date: new Date().toISOString().slice(0, 10), changes: [{ type: 'new', text: '' }] }
+
+function NoticeManager() {
+  const [subTab, setSubTab] = useState('patch')
+  const [items, setItems] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [editing, setEditing] = useState(null) // null | 'new' | item object
+  const [form, setForm] = useState({})
+
+  function load() {
+    setLoading(true)
+    const endpoint = subTab === 'patch' ? '/v1/notices/admin/patch-notes' : '/v1/notices/admin/announcements'
+    authFetch(endpoint)
+      .then(data => { setItems(data); setEditing(null) })
+      .catch(() => setItems([]))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { load() }, [subTab])
+
+  function startCreate() {
+    setForm(subTab === 'patch' ? { ...emptyPatchNote, changes: [{ type: 'new', text: '' }] } : { ...emptyAnnouncement })
+    setEditing('new')
+  }
+
+  function startEdit(item) {
+    setForm({ ...item })
+    setEditing(item)
+  }
+
+  async function handleSave() {
+    const isPatch = subTab === 'patch'
+    const isNew = editing === 'new'
+    const endpoint = isPatch
+      ? isNew ? '/v1/notices/patch-notes' : `/v1/notices/patch-notes/${form.id}`
+      : isNew ? '/v1/notices/announcements' : `/v1/notices/announcements/${form.id}`
+    await authFetch(endpoint, { method: isNew ? 'POST' : 'PUT', body: JSON.stringify(form) })
+    load()
+  }
+
+  async function handleDelete(id) {
+    if (!confirm('삭제하시겠습니까?')) return
+    const endpoint = subTab === 'patch' ? `/v1/notices/patch-notes/${id}` : `/v1/notices/announcements/${id}`
+    await authFetch(endpoint, { method: 'DELETE' })
+    load()
+  }
+
+  async function handleTogglePublish(item) {
+    const endpoint = subTab === 'patch' ? `/v1/notices/patch-notes/${item.id}` : `/v1/notices/announcements/${item.id}`
+    await authFetch(endpoint, { method: 'PUT', body: JSON.stringify({ is_published: !item.is_published }) })
+    load()
+  }
+
+  return (
+    <div>
+      {/* 서브탭 */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex gap-1">
+          {[['patch', '패치노트'], ['announce', '공지사항']].map(([key, label]) => (
+            <button key={key} onClick={() => { setSubTab(key); setEditing(null) }}
+              className="px-3 py-1 text-xs rounded-lg"
+              style={{ background: subTab === key ? 'var(--accent)' : 'var(--border)', color: subTab === key ? '#fff' : 'var(--text-secondary)' }}>
+              {label}
+            </button>
+          ))}
+        </div>
+        <button onClick={startCreate} className="px-3 py-1.5 text-xs rounded-lg font-medium" style={{ background: 'var(--accent)', color: '#fff' }}>
+          + 새로 작성
+        </button>
+      </div>
+
+      {/* 편집 폼 */}
+      {editing && (
+        <div className="rounded-xl p-4 mb-4" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}>
+          <h4 className="text-sm font-semibold mb-3" style={{ color: 'var(--text-primary)' }}>
+            {editing === 'new' ? '새로 작성' : '수정'}
+          </h4>
+          {subTab === 'patch' ? (
+            <PatchNoteForm form={form} onChange={setForm} />
+          ) : (
+            <AnnouncementForm form={form} onChange={setForm} />
+          )}
+          <div className="flex gap-2 mt-3 justify-end">
+            <button onClick={() => setEditing(null)} className="px-3 py-1.5 text-xs rounded-lg" style={{ background: 'var(--border)', color: 'var(--text-secondary)' }}>취소</button>
+            <button onClick={handleSave} className="px-3 py-1.5 text-xs rounded-lg font-medium" style={{ background: 'var(--accent)', color: '#fff' }}>저장</button>
+          </div>
+        </div>
+      )}
+
+      {/* 목록 */}
+      {loading ? (
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>불러오는 중...</p>
+      ) : items.length === 0 ? (
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>항목이 없습니다.</p>
+      ) : (
+        <div className="space-y-2">
+          {items.map(item => (
+            <div key={item.id} className="rounded-xl px-4 py-3 flex items-center justify-between"
+              style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)', opacity: item.is_published ? 1 : 0.5 }}>
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  {subTab === 'patch' && <span className="text-xs font-semibold" style={{ color: 'var(--accent)' }}>{item.version}</span>}
+                  <span className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>{item.title}</span>
+                  <span className="text-[11px] flex-shrink-0" style={{ color: 'var(--text-secondary)' }}>{item.date}</span>
+                  {!item.is_published && <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--text-secondary)' }}>비공개</span>}
+                  {item.pinned && <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(255,59,92,0.12)', color: 'var(--accent)' }}>고정</span>}
+                </div>
+                {subTab === 'patch' && item.changes && (
+                  <p className="text-[11px] mt-0.5" style={{ color: 'var(--text-secondary)' }}>변경 {item.changes.length}건</p>
+                )}
+              </div>
+              <div className="flex gap-1 flex-shrink-0 ml-3">
+                <button onClick={() => handleTogglePublish(item)} className="px-2 py-1 text-[11px] rounded"
+                  style={{ background: 'var(--border)', color: 'var(--text-secondary)' }}>
+                  {item.is_published ? '숨기기' : '공개'}
+                </button>
+                <button onClick={() => startEdit(item)} className="px-2 py-1 text-[11px] rounded"
+                  style={{ background: 'var(--border)', color: 'var(--text-secondary)' }}>수정</button>
+                <button onClick={() => handleDelete(item.id)} className="px-2 py-1 text-[11px] rounded"
+                  style={{ background: 'rgba(239,68,68,0.1)', color: '#f87171' }}>삭제</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function inputStyle() {
+  return { background: 'var(--bg-primary)', border: '1px solid var(--border)', color: 'var(--text-primary)', outline: 'none' }
+}
+
+function AnnouncementForm({ form, onChange }) {
+  const set = (k, v) => onChange({ ...form, [k]: v })
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-[1fr_120px] gap-2">
+        <input value={form.title || ''} onChange={e => set('title', e.target.value)} placeholder="제목"
+          className="px-3 py-1.5 text-xs rounded-lg" style={inputStyle()} />
+        <input type="date" value={form.date || ''} onChange={e => set('date', e.target.value)}
+          className="px-3 py-1.5 text-xs rounded-lg" style={inputStyle()} />
+      </div>
+      <textarea value={form.content || ''} onChange={e => set('content', e.target.value)} placeholder="내용"
+        rows={4} className="w-full px-3 py-2 text-xs rounded-lg resize-none" style={inputStyle()} />
+      <label className="flex items-center gap-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
+        <input type="checkbox" checked={form.pinned || false} onChange={e => set('pinned', e.target.checked)} />
+        상단 고정
+      </label>
+    </div>
+  )
+}
+
+function PatchNoteForm({ form, onChange }) {
+  const set = (k, v) => onChange({ ...form, [k]: v })
+  const changes = form.changes || []
+
+  function setChange(idx, key, val) {
+    const next = changes.map((c, i) => i === idx ? { ...c, [key]: val } : c)
+    set('changes', next)
+  }
+  function addChange() { set('changes', [...changes, { type: 'new', text: '' }]) }
+  function removeChange(idx) { set('changes', changes.filter((_, i) => i !== idx)) }
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-[80px_1fr_120px] gap-2">
+        <input value={form.version || ''} onChange={e => set('version', e.target.value)} placeholder="v0.0.0"
+          className="px-3 py-1.5 text-xs rounded-lg" style={inputStyle()} />
+        <input value={form.title || ''} onChange={e => set('title', e.target.value)} placeholder="제목"
+          className="px-3 py-1.5 text-xs rounded-lg" style={inputStyle()} />
+        <input type="date" value={form.date || ''} onChange={e => set('date', e.target.value)}
+          className="px-3 py-1.5 text-xs rounded-lg" style={inputStyle()} />
+      </div>
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <span className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>변경 사항</span>
+          <button onClick={addChange} className="text-[11px] px-2 py-0.5 rounded" style={{ background: 'var(--border)', color: 'var(--text-secondary)' }}>+ 추가</button>
+        </div>
+        {changes.map((c, i) => (
+          <div key={i} className="flex gap-1.5 items-center">
+            <select value={c.type} onChange={e => setChange(i, 'type', e.target.value)}
+              className="px-2 py-1.5 text-[11px] rounded-lg" style={inputStyle()}>
+              {CHANGE_TYPES.map(t => <option key={t} value={t}>{CHANGE_LABEL[t]}</option>)}
+            </select>
+            <input value={c.text} onChange={e => setChange(i, 'text', e.target.value)} placeholder="변경 내용"
+              className="flex-1 px-3 py-1.5 text-xs rounded-lg" style={inputStyle()} />
+            {changes.length > 1 && (
+              <button onClick={() => removeChange(i)} className="text-[11px] px-1.5 py-1 rounded" style={{ color: '#f87171' }}>✕</button>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- 공지사항 & 패치노트 시스템 추가 (백엔드 API + 프론트 모달 + Admin CRUD)
- 프로젝트 삭제 후 대화기록이 남아있는 버그 수정
- 사용자 입력 500자 제한 추가 (백엔드 1000자)

## Changes

### 공지사항 & 패치노트
- `Announcement`, `PatchNote` DB 모델 + Pydantic 스키마
- 공개 읽기 + 관리자 CRUD API (`/api/v1/notices/*`)
- Header에 "공지" 버튼 + NEW 뱃지 (localStorage 기반 읽음 처리)
- Admin 페이지 "공지 관리" 탭 (공지사항/패치노트 작성·수정·삭제·공개/비공개)

### 대화기록 버그 수정
- ChatInterface: localStorage 전용 → 백엔드 `/api/v1/llm/history` API 우선 fetch로 전환
- ConversationLog FK에 `ondelete=CASCADE` 추가
- SQLite `PRAGMA foreign_keys=ON` 활성화

### 입력 제한
- PromptInput: 500자 제한 + 글자수 카운터
- UserInputRequest 스키마: `max_length=1000`

## Test plan
- [ ] Admin → 공지 관리 탭에서 공지사항/패치노트 생성·수정·삭제
- [ ] Header 공지 버튼 클릭 → 모달에서 패치노트/공지사항 확인, NEW 뱃지 사라짐
- [ ] 프로젝트 삭제 → 새 프로젝트 생성 → 이전 대화기록 안 보이는지 확인
- [ ] 채팅 입력 500자 초과 시 입력 차단 + 카운터 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)