### PR TITLE
chore(deploy): EC2 배포 워크플로우 Docker 캐시 정리 정책 강화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,5 +35,7 @@ jobs:
             export DOCKER_BUILDKIT=1
             export COMPOSE_DOCKER_CLI_BUILD=1
             docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
-            # 사용 안 하는(dangling) 이미지 정리 — builder 캐시와는 별개
-            docker image prune -f
+            # 미사용 이미지 정리 (24시간 지난 항목 위주)
+            docker image prune -af --filter "until=24h"
+            # BuildKit 캐시를 24시간 기준으로 정리하되, 총 1GB는 유지
+            docker builder prune -af --filter "until=24h" --keep-storage 1GB


### PR DESCRIPTION
- 수정 파일: .github/workflows/deploy.yml
- 기존: docker image prune -f (dangling 이미지만 정리)
- 변경:
  - docker image prune -af --filter until=24h
  - docker builder prune -af --filter until=24h --keep-storage 1GB
- 효과:
  - 24시간 지난 미사용 이미지/빌드 캐시를 더 적극적으로 정리
  - EC2 디스크 누적 속도 완화
  - builder 캐시는 1GB 유지로 빌드 성능 저하를 최소화

## 지금 적용된 동작
deploy.yml에서 배포 빌드가 끝난 직후 아래 순서로 실행됩니다.

docker compose ... up -d --build

새 이미지 빌드 + 컨테이너 재기동
docker image prune -af --filter "until=24h"

대상: 현재 사용하지 않는 이미지(dangling 포함)
조건: 24시간 지난 것
특징: 실행 중 컨테이너가 붙잡고 있는 이미지는 삭제 안 됨
docker builder prune -af --filter "until=24h" --keep-storage 1GB

대상: BuildKit 빌드 캐시
조건: 24시간 지난 캐시 우선 정리
추가: 캐시 총량을 1GB 수준으로 유지하려고 정리