### PR TITLE
fix: profiler에 과도한 input값이 들어가는 현상을 막기 위해 few-shot 예시 제거

### DIFF
--- a/agent/graph/nodes/profiler.py
+++ b/agent/graph/nodes/profiler.py
@@ -165,8 +165,9 @@ async def profile_one(
     target_file = step.get("target_file", "")
     target_info = dict(step.get("target_info") or {})
 
-    # 기존 엔티티 예시 가져오기
-    examples = _get_existing_examples(game_id, target_file)
+    # 기존 엔티티 예시 가져오기 (병목 해결을 위해 비활성화)
+    # examples = _get_existing_examples(game_id, target_file)
+    examples = []
     schema_excerpt = get_schema_reference(target_file)
 
     system_prompt = build_profiler_system_prompt()


### PR DESCRIPTION
- profiler.py에서 few-shot으로 들어가는 input 예시가 너무 길어서 타임아웃 발생 및 토큰 소모량 과도

```python
    # 기존 엔티티 예시 가져오기 (병목 해결을 위해 비활성화)
    # examples = _get_existing_examples(game_id, target_file)
    examples = []
```
- 우선 examples을 빈 배열로 두기로 했읍니다 ,,
