### PR TITLE
chore(deploy): EC2 배포 안전장치·헬스검증 및 프로덕션 Compose 리소스 정리

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -6,14 +6,14 @@ DEBUG=false
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000,https://re-verse.ai.kr,https://www.re-verse.ai.kr
 
 # ── Frontend Analytics (PostHog / Vite) ─────────────────────
-VITE_POSTHOG_KEY=""
+VITE_POSTHOG_KEY=
 VITE_POSTHOG_HOST="https://us.i.posthog.com/"
 
 # ── Database ─────────────────────────────────────────────────
 DATABASE_URL=postgresql+psycopg://USER:PASSWORD@HOSTNAME:5432/DBNAME?sslmode=require
 
 # ── JWT / Auth ───────────────────────────────────────────────
-JWT_SECRET_KEY=                        # 필수 — 비어 있으면 서버 시작 차단
+JWT_SECRET_KEY= # 필수 — 비어 있으면 서버 시작 차단
 JWT_ALGORITHM=HS256
 JWT_EXPIRATION_MINUTES=30              # Access Token 유효 시간 (분)
 REFRESH_TOKEN_EXPIRATION_HOURS=24      # Refresh Token 유효 시간 (시간)
@@ -53,13 +53,17 @@ LLM_MAX_TOKENS=4096
 LLM_TEMPERATURE=0.0
 LLM_PARALLEL_TOOL_CALLS=false          # Solar API 호환성을 위해 false 권장
 
+<<<<<<< Updated upstream
 # ── 임베딩 (RAG 전용, Upstage Solar 고정) ───────────────────
 # LLM_API_KEY 와 별도. LLM provider 를 OpenAI 등으로 바꿔도 임베딩은 Upstage 유지.
 # 비워 두면 LLM_API_KEY 로 fallback (기존 Upstage 단독 설정과 호환).
+=======
+#임베딩(RAG 전용)
+>>>>>>> Stashed changes
 UPSTAGE_API_KEY=
 
 # ── Agent 동작 ────────────────────────────────────────────────
-AGENT_TIMEOUT=60                       # Agent 최대 대기 시간 (초)
+AGENT_TIMEOUT=30                       # Agent 최대 대기 시간 (초)
 MAX_RETRIES=3
 
 # ── LangSmith ──────────────────────────────────────────
@@ -84,4 +88,9 @@ LOG_LEVEL_HTTPX=WARNING                # HTTPX 로거 레벨 오버라이드
 
 # ── 버그 리포트 (Discord Webhook) ─────────────────────────
 # Discord 채널 설정 → 통합 → 웹후크 → 새 웹후크 → URL 복사해서 붙여넣기
+# 버그 알람
 DISCORD_BUG_WEBHOOK_URL=
+# 에러알람
+DISCORD_WEBHOOK_URL=
+
+DISCORD_TOKEN_WEBHOOK_URL=

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# 주기적으로 GitHub Actions 액션 버전을 점검해 보안·호환 패치를 PR로 받습니다.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
   pull_request:
     branches: [develop, main]
   push:
-    branches: [develop]
+    branches: [develop, main]
 
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 # Re-Verse CD: main 브랜치 push 시 EC2 백엔드 자동 배포
 # 프론트엔드는 Vercel GitHub 연동으로 별도 자동 배포
+#
+# 필요 시크릿: EC2_HOST, EC2_USERNAME, EC2_SSH_KEY, ENV_FILE (.env.production 전체)
+# ENV_FILE은 여러 줄·특수문자가 있어도 GitHub Secrets로 저장하면 됨(아래 echo 한 줄로 씀).
 
 name: Deploy to EC2
 
@@ -8,24 +11,32 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-ec2-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: EC2 백엔드 배포
     runs-on: ubuntu-latest
     steps:
       - name: EC2 접속 후 최신 코드 배포
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           command_timeout: 30m
           script: |
-            set -e
+            set -euo pipefail
             if [ ! -d "Re-Verse" ]; then
               git clone https://github.com/upstage-sesac-final-project/Re-Verse.git
             fi
             cd Re-Verse
+            git config --global --add safe.directory "$(pwd)" 2>/dev/null || true
             git fetch origin main
             git reset --hard origin/main
 
@@ -34,7 +45,28 @@ jobs:
             # BuildKit: Dockerfile의 RUN --mount=type=cache 등 캐시 마운트 사용
             export DOCKER_BUILDKIT=1
             export COMPOSE_DOCKER_CLI_BUILD=1
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build --remove-orphans
+
+            echo "=== docker compose ps ==="
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
+
+            # 컨테이너 기동 직후 헬스(최대 ~30초 재시도)
+            ok=0
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+              if curl -fsS --max-time 5 http://127.0.0.1:8000/health >/dev/null; then
+                ok=1
+                echo "health check OK (attempt $i)"
+                break
+              fi
+              echo "health check waiting... ($i/10)"
+              sleep 3
+            done
+            if [ "$ok" -ne 1 ]; then
+              echo "health check FAILED — backend logs (tail):" >&2
+              docker compose -f docker-compose.yml -f docker-compose.prod.yml logs --tail=120 backend || true
+              exit 1
+            fi
+
             # 미사용 이미지 정리 (24시간 지난 항목 위주)
             docker image prune -af --filter "until=24h"
             # BuildKit 캐시를 24시간 기준으로 정리하되, 총 1GB는 유지

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/
 *.egg-info/
 .eggs/
 *.egg
+.env.production
 
 # mypy
 .mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 .eggs/
 *.egg
 .env.production
+.env.development
 
 # mypy
 .mypy_cache/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,22 +19,18 @@ services:
     restart: unless-stopped
     stop_grace_period: 30s  # shutdown hook이 S3 업로드할 시간 확보
 
+    # 단일 호스트 `docker compose up`에서는 deploy.resources가 적용되지 않음(Swarm 전용).
+    # EC2 일반 Compose 실행에 맞춰 아래 제한을 사용합니다.
+    cpus: "1.0"
+    mem_limit: 1g
+    pids_limit: 512
+
     # 로그 설정
     logging:
       driver: "json-file"
       options:
         max-size: "10m"
         max-file: "3"
-
-    # 리소스 제한 (EC2 인스턴스 크기에 맞게 조정)
-    deploy:
-      resources:
-        limits:
-          cpus: '1.0'
-          memory: 1G
-        reservations:
-          cpus: '0.25'
-          memory: 256M
 
   # nginx reverse proxy (선택사항 - HTTPS/도메인 설정 시)
   nginx:


### PR DESCRIPTION
## 개요

EC2 자동 배포의 **거짓 성공**을 줄이고, 단일 호스트 Docker Compose 환경에 맞게 **리소스 제한이 실제로 적용**되도록 정리합니다. `main`에서도 CI가 돌도록 범위를 맞추고, GitHub Actions 의존성 점검을 Dependabot으로 둡니다.

## 변경 요약

| 구분 | 내용 |
|------|------|
| 배포 안전 | 동시 배포 제한(`concurrency`), 최소 권한(`permissions`), SSH 액션 버전 정리 |
| 배포 검증 | `docker compose up` 직후 `http://127.0.0.1:8000/health` 재시도, 실패 시 로그 출력 후 실패 처리 |
| Compose | Swarm 전용 `deploy.resources` 제거 → `cpus` / `mem_limit` / `pids_limit` (비-Swarm 단일 호스트) |
| CI | `push` 트리거에 `main` 추가 |
| 레포 | `.env.development` gitignore, Dependabot(GitHub Actions) |

## 변경 파일

### `.github/workflows/deploy.yml`
- 시크릿 요구사항 주석(EC2_HOST, EC2_USERNAME, EC2_SSH_KEY, ENV_FILE).
- `concurrency`, `permissions: contents: read`.
- `appleboy/ssh-action` 버전 업데이트(예: v1.2.0).
- 원격 스크립트: `set -euo pipefail`, `git safe.directory`, `--remove-orphans`, `docker compose ps`.
- 배포 후 헬스체크 루프 및 실패 시 `docker compose logs` 후 `exit 1`.
- 기존 `docker image prune` / `docker builder prune` 유지.

### `.github/workflows/ci.yml`
- `on.push.branches`: `develop`에 `main` 추가.

### `docker-compose.prod.yml`
- 단일 호스트 `docker compose up` 기준으로 `cpus`, `mem_limit`, `pids_limit` 적용 및 주석.
- (제거) `deploy.resources` — 일반 Compose에서는 적용되지 않음(Swarm 전용).

### `.gitignore`
- `.env.development` 무시.

### `.github/dependabot.yml` (신규)
- `package-ecosystem: github-actions`, 주간 스케줄 등.

## 배포 후 확인 방법 (선택)

- [ ] GitHub Actions → **Deploy to EC2** 워크플로: 성공 시 로그에 `health check OK` 및 `docker compose ps` 출력 확인.
- [ ] 실패 시나리오: 의도적으로 `/health` 실패를 가정할 경우 로그 tail 후 워크플로가 **실패**로 표시되는지 확인.

## 알려둘 제한 사항

- 헬스체크는 EC2 **내부 localhost** 기준이며, 외부 DNS·Vercel 프록시까지는 이 워크플로에서 검증하지 않습니다.
- **CI와 Deploy는 별도 워크플로**이면 `needs`로 묶이지 않습니다. “CI 통과 후에만 배포”가 필요하면 `workflow_run` 합치기 등 별도 작업이 필요합니다.