### PR TITLE
fix(backend): orphan game 폴더 누적 방지 및 디버깅 로그 추가

### DIFF
--- a/app/backend/db/session.py
+++ b/app/backend/db/session.py
@@ -61,6 +61,9 @@ def get_engine() -> AsyncEngine | None:
             cursor.execute("PRAGMA journal_mode=WAL")
             cursor.execute("PRAGMA busy_timeout=5000")
             cursor.execute("PRAGMA foreign_keys=ON")
+            # 기본값 1000페이지 → 100페이지로 낮춰 WAL을 자주 checkpoint
+            # 서버 비정상 종료 시 소실되는 미checkpoint 데이터를 최소화
+            cursor.execute("PRAGMA wal_autocheckpoint=100")
             cursor.close()
 
     logger.info("AsyncSQLAlchemy engine 초기화 완료")

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -56,6 +56,50 @@ class RequestIdASGIMiddleware:
         await self.app(scope, receive, send_wrapper)
 
 
+async def _cleanup_db_orphan_folders() -> None:
+    """DB에 game_id 레코드가 없는 game 폴더를 startup 시 삭제 (로컬/S3 공통).
+
+    S3 모드에서는 DB에 없는 폴더를 S3 업로드 없이 바로 삭제한다.
+    S3에 저장된 데이터는 delete_project 호출 시 S3에서도 삭제되므로,
+    DB 레코드가 없다면 해당 프로젝트는 이미 삭제된 것으로 간주한다.
+    """
+    from sqlalchemy import select
+
+    from app.backend.db.session import _async_session
+    from app.backend.models.game import Project
+
+    storage_path = Path(settings.STORAGE_PATH).resolve()
+    if not storage_path.is_dir():
+        return
+    if _async_session is None:
+        logger.debug("[Orphan] DB 세션 없음 — 건너뜀")
+        return
+
+    try:
+        async with _async_session() as session:
+            result = await session.execute(select(Project.game_id))
+            db_game_ids: set[str] = set(result.scalars().all())
+    except Exception:
+        logger.warning("[Orphan] DB 조회 실패 — 건너뜀", exc_info=True)
+        return
+
+    orphan_dirs = [
+        child
+        for child in storage_path.iterdir()
+        if child.is_dir() and child.name.startswith("game_") and child.name not in db_game_ids
+    ]
+    if not orphan_dirs:
+        return
+
+    logger.info("[Orphan] DB에 없는 game 폴더 %d개 발견, 정리 시작", len(orphan_dirs))
+    for orphan_dir in orphan_dirs:
+        try:
+            shutil.rmtree(orphan_dir)
+            logger.info("[Orphan] 삭제 완료 | %s", orphan_dir.name)
+        except Exception:
+            logger.warning("[Orphan] 삭제 실패 | %s", orphan_dir.name, exc_info=True)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
@@ -112,6 +156,9 @@ async def lifespan(app: FastAPI):
     # DB 테이블 생성 (checkfirst=True, 기존 데이터 보존)
     await init_db()
 
+    # DB에 없는 orphan game 폴더 정리 (로컬/S3 공통)
+    await _cleanup_db_orphan_folders()
+
     setup_langsmith()
 
     # 주기적 인메모리 상태 정리 (60초마다)
@@ -149,6 +196,19 @@ async def lifespan(app: FastAPI):
                 logger.info("Shutdown: S3 업로드 + 정리 완료 | %s", game_id)
             except Exception:
                 logger.error("Shutdown: S3 업로드 실패 | %s", game_id, exc_info=True)
+
+    # SQLite WAL checkpoint 보장: engine.dispose()로 연결을 정상 종료
+    # dispose() 없이 프로세스가 죽으면 WAL → main DB checkpoint가 실행되지 않아
+    # 재시작 시 커밋된 데이터가 소실될 수 있음
+    from app.backend.db.session import get_engine
+
+    engine = get_engine()
+    if engine is not None:
+        try:
+            await engine.dispose()
+            logger.info("DB engine disposed (WAL checkpoint 완료)")
+        except Exception:
+            logger.warning("DB engine dispose 실패", exc_info=True)
 
 
 app = FastAPI(

--- a/app/backend/services/game_service.py
+++ b/app/backend/services/game_service.py
@@ -70,9 +70,13 @@ class GameService:
 
         try:
             self._copy_base_game(game_id)
+            logger.debug("[GameService] 폴더 생성 완료, DB 커밋 시작 | game_id=%s", game_id)
             await project_repository.commit(db)
             await project_repository.refresh(project, db)
-        except Exception:
+        except BaseException as exc:
+            # CancelledError(BaseException 하위)도 포함 — 클라이언트 연결 끊김·요청 취소 시
+            # except Exception만 쓰면 CancelledError가 빠져나가 cleanup이 실행되지 않고
+            # 폴더만 남는 orphan이 발생한다
             logger.error(
                 "[GameService] 프로젝트 생성 실패 — 롤백 | user_id=%d, game_id=%s",
                 user_id,
@@ -81,10 +85,13 @@ class GameService:
             )
             await project_repository.rollback(db)
             self._cleanup_game_folder(game_id)
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="프로젝트 생성 중 오류가 발생했습니다.",
-            )
+            if isinstance(exc, Exception):
+                # 일반 예외는 HTTPException으로 변환해 클라이언트에 500 반환
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="프로젝트 생성 중 오류가 발생했습니다.",
+                ) from exc
+            raise  # CancelledError 등 BaseException은 그대로 전파
         logger.info(
             "[GameService] 프로젝트 생성 완료 | user_id=%d, project_id=%d, game_id=%s",
             user_id,
@@ -156,10 +163,13 @@ class GameService:
 
         unregister_session(game_id)
         remove_game_lock(game_id)
+        logger.debug("[GameService] DB 삭제 완료, 폴더 삭제 시작 | game_id=%s", game_id)
         try:
             self._delete_game_folder(game_id)
         except Exception:
-            logger.warning("게임 폴더 삭제 실패 (orphan): game_id=%s", game_id)
+            logger.warning(
+                "[GameService] 게임 폴더 삭제 실패 (orphan) | game_id=%s", game_id, exc_info=True
+            )
 
     # ── 파일 시스템 헬퍼 ──────────────────────────────────
 
@@ -180,14 +190,19 @@ class GameService:
             self._s3_delete_game(game_id)
         else:
             target = Path(settings.STORAGE_PATH).resolve() / game_id
-            if target.exists():
-                shutil.rmtree(target)
+            if not target.exists():
+                logger.warning(
+                    "[GameService] 폴더 없음 — 이미 삭제됐거나 경로 불일치 | path=%s", target
+                )
+                return
+            shutil.rmtree(target)
+            logger.debug("[GameService] 폴더 삭제 완료 | game_id=%s", game_id)
 
     def _cleanup_game_folder(self, game_id: str) -> None:
         try:
             self._delete_game_folder(game_id)
         except Exception:
-            logger.warning("롤백 중 폴더 정리 실패: game_id=%s", game_id)
+            logger.warning("롤백 중 폴더 정리 실패 | game_id=%s", game_id, exc_info=True)
 
     def _s3_copy_base_game(self, game_id: str) -> None:
         client = boto3.client("s3", region_name=settings.AWS_REGION)


### PR DESCRIPTION
## 문제
프로젝트 생성 중 서버 재시작 또는 요청 취소(CancelledError) 시 game 폴더만 생성되고 DB 레코드는 커밋되지 않아 orphan 폴더가 누적됨 → 여러 팀원에게 공통으로 발생

## 원인
- `except Exception`은 `CancelledError`(BaseException 하위)를 잡지 못해 cleanup이 실행되지 않고 폴더가 남음
- shutdown 시 `engine.dispose()` 누락으로 SQLite WAL checkpoint 미보장
- startup orphan 정리 로직이 S3 모드에만 존재하고 DB 기반이 아니었음

## 변경 사항
- `game_service.py`: `except BaseException`으로 변경, CancelledError 시 cleanup 보장
- `main.py`: startup 시 DB와 storage 비교해 orphan 폴더 자동 삭제, shutdown 시 `engine.dispose()` 추가
- `session.py`: `wal_autocheckpoint=100` 추가 (SQLite WAL 조기 checkpoint)
- `game_service.py`: 폴더 생성/삭제 시점 로그 추가, `exc_info=True` 누락 수정