### PR TITLE
fix: PID 및 리소스 설정 충돌 해결

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,12 +23,6 @@ services:
     restart: unless-stopped
     stop_grace_period: 30s  # shutdown hook이 S3 업로드할 시간 확보
 
-    # 단일 호스트 `docker compose up`에서는 deploy.resources가 적용되지 않음(Swarm 전용).
-    # EC2 일반 Compose 실행에 맞춰 아래 제한을 사용합니다.
-    cpus: "1.0"
-    mem_limit: 1g
-    pids_limit: 512
-
     # 로그 설정
     logging:
       driver: "json-file"
@@ -42,6 +36,7 @@ services:
         limits:
           cpus: '1.0'
           memory: 1G
+          pids_limit: 512
         reservations:
           cpus: '0.25'
           memory: 256M


### PR DESCRIPTION
- 주석에는 "deploy.resources가 적용되지 않음"이라고 적혀 있지만, Docker Compose V2부터는 docker compose up 명령 시에도 deploy 섹션의 제한 사항을 기본적으로 읽어들입니다. 따라서 두 곳에 모두 적혀 있는 설정이 서로 부딪히고 있습니다.
- cpus, mem_limit 등이 상위 레벨과 deploy 레벨에 중복되어 있습니다.
- 상위 레벨 리소스 설정 삭제: cpus: "1.0", mem_limit: 1g, pids_limit: 512를 삭제했습니다.