### PR TITLE
fix(editor): 게임 뷰어 새로고침 조건 개선 및 base_game 에셋 캐싱 추가

### DIFF
--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -300,9 +300,10 @@ async def serve_game_file(game_id: str, path: str):
         )
         return RedirectResponse(url=s3_url, status_code=302)
     # 3) base_game 공유 에셋 (img, js, css, audio 등 — data/ 제외)
+    #    Cache-Control: max-age=3600 → iframe 재생성 시 304 재검증 없이 캐시에서 직접 로드
     base_file = Path(settings.BASE_GAME_PATH).resolve() / path
     if base_file.is_file():
-        return FileResponse(str(base_file))
+        return FileResponse(str(base_file), headers={"Cache-Control": "public, max-age=3600"})
     # 4) S3 redirect fallback (EC2에 base_game 없을 때)
     if settings.STORAGE_BACKEND == "s3":
         s3_prefix = settings.S3_PREFIX.strip("/")

--- a/app/frontend/src/components/chat/ChatInterface.jsx
+++ b/app/frontend/src/components/chat/ChatInterface.jsx
@@ -65,7 +65,7 @@ export default function ChatInterface({ projectId, onGameUpdate, isCollapsed, on
     try {
       const response = await sendPrompt(text, projectId)
       setMessages((prev) => [...prev, { id: id + 1, ...response }])
-      onGameUpdate?.()
+      if (response.reload_required) onGameUpdate?.()
     } catch (err) {
       setMessages((prev) => [
         ...prev,

--- a/app/frontend/src/services/llmApi.js
+++ b/app/frontend/src/services/llmApi.js
@@ -51,5 +51,6 @@ export async function sendPrompt(message, projectId) {
     intent: data.intent,
     affected_files: data.affected_files,
     changes_log: data.changes_log ?? [],
+    reload_required: data.reload_required ?? false,
   }
 }


### PR DESCRIPTION
## 변경 사항

### 문제
1. **불필요한 새로고침**: 조회 명령("캐릭터 목록 알려줘" 등) 이후에도 게임 뷰어 iframe이 항상 새로고침됨
2. **이미지 미표시**: EC2 환경에서 새로고침 시 이미지 요청이 304로 응답되면서 타이틀 배경 이미지가 검은  화면으로 표시되는 버그

### 원인
1. `ChatInterface`에서 `onGameUpdate()` 가 LLM 응답 후 무조건 호출되어, 게임 데이터 변경이 없는 조회 응답에도 iframe을 재생성함
2. `FileResponse`에 `Cache-Control` 헤더가 없어 브라우저가 iframe 재생성 시마다 조건부 재검증 요청(304)을 보내고, RPG Maker MZ의 Scene_Title이 이 응답에서 배경 이미지를 표시하지 못함

### 수정 내용
- `llmApi.js`: 백엔드 응답의 `reload_required` 값을 프론트에 전달
- `ChatInterface.jsx`: `reload_required: true` 일 때만 `onGameUpdate()` 호출 (생성/수정 시에만 새로고침)
- `main.py`: base_game 정적 에셋(img, audio, js 등) 응답에 `Cache-Control: public, max-age=3600` 추가 → iframe 재생성 시 서버 재검증 없이 캐시에서 직접 로드

## 테스트
- [ ] 조회 명령 후 게임 뷰어 새로고침 없음 확인
- [ ] 생성/수정 명령 후 게임 뷰어 정상 새로고침 확인
- [ ] EC2 배포 환경에서 새로고침 후 타이틀 배경 이미지 정상 표시 확인