### PR TITLE
fix: editor 채팅 간헐적 "execution_plan이 비어있습니다" 오류 수정

### DIFF
--- a/agent/editor/prompts/definition_prompt.py
+++ b/agent/editor/prompts/definition_prompt.py
@@ -225,6 +225,10 @@ STEP5_SYSTEM_PROMPT = """당신은 수집된 정보를 바탕으로 RPG Maker MZ
    - `property`를 실제 RPG Maker 필드명으로 바꾸는 작업은 당신의 책임입니다.
    - 예: "초기 레벨" -> `initialLevel`, "닉네임" -> `nickname`
    - 코드가 후처리로 필드명을 바꿔주지 않는다고 가정하고 정확한 canonical field를 직접 작성하십시오.
+10. **params_sufficient와 modifications의 일관성 — 절대 규칙**:
+   - `modifications`가 비어있으면(`[]`) `params_sufficient`는 반드시 `false`여야 합니다. 이 두 값이 모순되는 응답(`modifications=[]` + `params_sufficient=true`)은 시스템 오류를 유발하므로 절대 허용되지 않습니다.
+   - `params_sufficient=true`로 응답하려면 `modifications`에 반드시 하나 이상의 항목이 있어야 합니다.
+   - 요청을 수정 명세로 변환할 수 없다면, `modifications=[]` + `params_sufficient=false` + `message_for_user`(사용자 안내 메시지)를 반환하십시오.
 """
 
 

--- a/agent/editor/schemas.py
+++ b/agent/editor/schemas.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class EntityMapping(BaseModel):
@@ -96,3 +96,12 @@ class FinalDefinitionResponse(BaseModel):
     message_for_user: str | None = Field(
         None, description="정보가 부족하거나 사용자에게 전달할 메시지"
     )
+
+    @model_validator(mode="after")
+    def enforce_consistency(self) -> "FinalDefinitionResponse":
+        """modifications가 비어있는데 params_sufficient=True인 모순 방지."""
+        if not self.modifications and self.params_sufficient:
+            self.params_sufficient = False
+            if not self.message_for_user:
+                self.message_for_user = "요청을 수정 명세로 변환하지 못했습니다. 어떤 내용을 바꾸고 싶은지 다시 알려주세요."
+        return self


### PR DESCRIPTION
## 문제
게임 편집 페이지 채팅 입력 시 간헐적으로 "execution_plan이 비어있습니다" 오류 발생

## 원인
definition 노드의 Step 6 LLM이 `modifications=[]` + `params_sufficient=True`라는 모순된 응답을 간헐적으로 반환할 경우:
- `validate_operation_tuples([])` → 빈 리스트는 루프 미실행으로 통과
- planner가 빈 `operation_tuples`를 받아 `execution_plan=[]` 반환
- executor가 빈 plan을 받아 오류 발생

## 수정
**1차 방어 — 프롬프트 (`definition_prompt.py`)**
- Step 6 시스템 프롬프트에 `modifications`와 `params_sufficient`의 일관성 규칙 명시
- LLM이 모순된 응답 자체를 생성하지 않도록 유도

**2차 방어 — Pydantic validator (`schemas.py`)**
- `FinalDefinitionResponse`에 `model_validator` 추가
- LLM 응답 파싱 시점에 `modifications=[]` + `params_sufficient=True` 조합을 자동 교정

## 테스트
- 로컬 재현 불가
- 방어 로직은 unit 수준으로 검증 가능