### PR TITLE
fix: 프로젝트별 System.gameId 고유화로 세이브 교차 접근 차단 

### DIFF
--- a/agent/generation/nodes/integrator.py
+++ b/agent/generation/nodes/integrator.py
@@ -7,6 +7,7 @@ canonical: docs/The_world/IMPLEMENTATION_GUIDE.md §4.H
 
 import json
 import logging
+import secrets
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -536,7 +537,9 @@ def build_system_json_phase2(
         "tileSize": 48,
         "titleCommandWindow": {"background": 0, "offsetX": 0, "offsetY": 0},
         "advanced": {
-            "gameId": 72894844,
+            # 프로젝트별 고유 gameId — 같은 origin 에서 localStorage(`rmmzsave.<gameId>.*`)
+            # 가 섞이지 않도록 1..2^31-1 범위의 난수로 생성.
+            "gameId": secrets.randbelow(2**31 - 1) + 1,
             "screenWidth": 816,
             "screenHeight": 624,
             "uiAreaWidth": 816,

--- a/app/backend/services/game_service.py
+++ b/app/backend/services/game_service.py
@@ -5,7 +5,9 @@ Executor는 이 서비스를 호출하지 않는다.
 """
 
 import asyncio
+import json
 import logging
+import secrets
 import shutil
 import uuid
 from pathlib import Path
@@ -184,6 +186,53 @@ class GameService:
                 raise FileNotFoundError(f"base_game/data 경로 없음: {src}")
             shutil.copytree(src, dst)
             ensure_rpgmaker_mz_project_shell(Path(settings.STORAGE_PATH).resolve() / game_id)
+        # base_game 의 고정 gameId(72894844) 를 프로젝트 고유값으로 덮어쓰기 —
+        # 같은 origin 에서 RPG Maker MZ 가 localStorage 키(`rmmzsave.<gameId>.*`)를
+        # gameId 로만 격리하므로, 프로젝트별로 반드시 달라야 세이브가 섞이지 않는다.
+        self._randomize_system_game_id(game_id)
+
+    def _randomize_system_game_id(self, game_id: str) -> None:
+        """복사된 System.json 의 advanced.gameId 를 프로젝트 고유 32-bit 양수로 갱신."""
+        new_game_id = secrets.randbelow(2**31 - 1) + 1  # 1..2^31-1
+        if settings.STORAGE_BACKEND == "s3":
+            self._s3_randomize_system_game_id(game_id, new_game_id)
+            return
+        system_path = Path(settings.STORAGE_PATH).resolve() / game_id / "data" / "System.json"
+        if not system_path.exists():
+            logger.warning(
+                "[GameService] System.json 없음 — gameId 갱신 생략 | path=%s", system_path
+            )
+            return
+        data = json.loads(system_path.read_text(encoding="utf-8"))
+        data.setdefault("advanced", {})["gameId"] = new_game_id
+        system_path.write_text(
+            json.dumps(data, ensure_ascii=False, separators=(",", ":")), encoding="utf-8"
+        )
+        logger.debug("[GameService] System.gameId 갱신 | game_id=%s, new=%d", game_id, new_game_id)
+
+    def _s3_randomize_system_game_id(self, game_id: str, new_game_id: int) -> None:
+        client = boto3.client("s3", region_name=settings.AWS_REGION)
+        bucket = settings.S3_BUCKET_NAME
+        prefix = settings.S3_PREFIX.strip("/")
+        key = f"{prefix}/{game_id}/data/System.json"
+        try:
+            obj = client.get_object(Bucket=bucket, Key=key)
+        except ClientError as e:
+            logger.warning(
+                "[GameService] S3 System.json 조회 실패 — gameId 갱신 생략 | key=%s: %s", key, e
+            )
+            return
+        data = json.loads(obj["Body"].read().decode("utf-8"))
+        data.setdefault("advanced", {})["gameId"] = new_game_id
+        client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=json.dumps(data, ensure_ascii=False, separators=(",", ":")).encode("utf-8"),
+            ContentType="application/json",
+        )
+        logger.debug(
+            "[GameService] S3 System.gameId 갱신 | game_id=%s, new=%d", game_id, new_game_id
+        )
 
     def _delete_game_folder(self, game_id: str) -> None:
         if settings.STORAGE_BACKEND == "s3":

--- a/scripts/backfill_system_game_id.py
+++ b/scripts/backfill_system_game_id.py
@@ -1,0 +1,135 @@
+"""기존 프로젝트 System.json 의 advanced.gameId 를 프로젝트별 고유값으로 백필.
+
+base_game 의 고정 gameId(72894844) 를 그대로 상속한 기존 프로젝트들은 같은 origin
+(`/game/<id>/`) 에서 localStorage 키(`rmmzsave.<gameId>.*`)가 충돌해 다른 게임의
+세이브로 "이어하기" 가 활성화된다. 이 스크립트는 각 프로젝트에 1..2^31-1 범위의
+고유 난수를 주입한다.
+
+사용:
+    uv run python scripts/backfill_system_game_id.py            # dry-run (변경 없음)
+    uv run python scripts/backfill_system_game_id.py --apply    # 실제 적용
+    uv run python scripts/backfill_system_game_id.py --apply --force
+        # BASE_GAME_ID 가 아니어도 전부 덮어쓰기 (기존에 임의값이 있어도 초기화)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import secrets
+import sys
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.backend.core.config import settings  # noqa: E402
+
+BASE_GAME_ID = 72894844
+
+
+def _new_game_id() -> int:
+    return secrets.randbelow(2**31 - 1) + 1
+
+
+def _patch_system(data: dict, force: bool) -> tuple[bool, int | None]:
+    current = data.get("advanced", {}).get("gameId")
+    if current != BASE_GAME_ID and not force:
+        return False, current
+    new_id = _new_game_id()
+    data.setdefault("advanced", {})["gameId"] = new_id
+    return True, new_id
+
+
+def _iter_local_projects() -> list[Path]:
+    root = Path(settings.STORAGE_PATH).resolve()
+    if not root.exists():
+        return []
+    return [
+        p
+        for p in root.iterdir()
+        if p.is_dir() and p.name != "base_game" and (p / "data" / "System.json").exists()
+    ]
+
+
+def _run_local(apply: bool, force: bool) -> None:
+    projects = _iter_local_projects()
+    print(f"[local] 발견된 프로젝트: {len(projects)}개 (base_game 제외)")
+    patched = 0
+    skipped = 0
+    for proj in projects:
+        sys_path = proj / "data" / "System.json"
+        data = json.loads(sys_path.read_text(encoding="utf-8"))
+        changed, new_id = _patch_system(data, force=force)
+        if not changed:
+            skipped += 1
+            print(f"  - SKIP {proj.name}: gameId={new_id} (이미 고유 또는 force=False)")
+            continue
+        if apply:
+            sys_path.write_text(
+                json.dumps(data, ensure_ascii=False, separators=(",", ":")), encoding="utf-8"
+            )
+        patched += 1
+        print(f"  - {'APPLY' if apply else 'DRY'} {proj.name}: gameId → {new_id}")
+    print(f"[local] 완료: 갱신={patched}, 건너뜀={skipped}, apply={apply}")
+
+
+def _run_s3(apply: bool, force: bool) -> None:
+    client = boto3.client("s3", region_name=settings.AWS_REGION)
+    bucket = settings.S3_BUCKET_NAME
+    prefix = settings.S3_PREFIX.strip("/")
+    paginator = client.get_paginator("list_objects_v2")
+
+    game_ids: set[str] = set()
+    for page in paginator.paginate(Bucket=bucket, Prefix=f"{prefix}/", Delimiter="/"):
+        for cp in page.get("CommonPrefixes", []) or []:
+            name = cp["Prefix"][len(prefix) + 1 :].rstrip("/")
+            if name and name != "base_game":
+                game_ids.add(name)
+
+    print(f"[s3] 발견된 프로젝트: {len(game_ids)}개")
+    patched = 0
+    skipped = 0
+    for gid in sorted(game_ids):
+        key = f"{prefix}/{gid}/data/System.json"
+        try:
+            obj = client.get_object(Bucket=bucket, Key=key)
+        except ClientError as e:
+            print(f"  - MISS {gid}: System.json 없음 ({e})")
+            continue
+        data = json.loads(obj["Body"].read().decode("utf-8"))
+        changed, new_id = _patch_system(data, force=force)
+        if not changed:
+            skipped += 1
+            print(f"  - SKIP {gid}: gameId={new_id}")
+            continue
+        if apply:
+            client.put_object(
+                Bucket=bucket,
+                Key=key,
+                Body=json.dumps(data, ensure_ascii=False, separators=(",", ":")).encode("utf-8"),
+                ContentType="application/json",
+            )
+        patched += 1
+        print(f"  - {'APPLY' if apply else 'DRY'} {gid}: gameId → {new_id}")
+    print(f"[s3] 완료: 갱신={patched}, 건너뜀={skipped}, apply={apply}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--apply", action="store_true", help="실제로 파일을 수정 (기본: dry-run)")
+    ap.add_argument("--force", action="store_true", help="BASE_GAME_ID 가 아니어도 강제로 덮어쓰기")
+    args = ap.parse_args()
+
+    backend = (settings.STORAGE_BACKEND or "local").lower()
+    print(f"STORAGE_BACKEND={backend}, apply={args.apply}, force={args.force}")
+    if backend == "s3":
+        _run_s3(apply=args.apply, force=args.force)
+    else:
+        _run_local(apply=args.apply, force=args.force)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 배경                                                         

  배포 환경에서 **새로 생성한 프로젝트인데도 "이어하기"가 활성화되고, 클릭 시 다른 게임의 세이브로 진행되는 문제** 가 발생했습니다. 원인을 추적해 보니 세이브가 프로젝트별로 격리되지 않고 공유되고 있었습니다.                                               
   
  ## 원인                                                                                                                                                                                                                                                     
                                                                  
  1. 모든 게임이 **같은 origin의 `/game/<id>/` 경로**에서 서빙되기 때문에 브라우저 localStorage가 도메인 단위로 공유됩니다.                                                                                                                                   
  2. RPG Maker MZ 엔진은 세이브를 아래 키로 localStorage에 저장합니다:
     ```js                                                                                                                                                                                                                                                    
     // rmmz_managers.js                                          
     "rmmzsave." + $dataSystem.advanced.gameId + "." + saveName                                                                                                                                                                                               
  3. $dataSystem.advanced.gameId 는 각 프로젝트의 data/System.json 에서 읽는데,                                                                                                                                                                               
    - storage/games/base_game/data/System.json 의 advanced.gameId 가 72894844 로 고정되어 있고,                                                                                                                                                               
    - 프로젝트 생성 시 shutil.copytree 로 그대로 복사되기 때문에 모든 프로젝트가 동일한 gameId를 공유하게 됩니다.                                                                                                                                             
  4. 동시에 AI 생성 경로(agent/generation/nodes/integrator.py)에서도 gameId: 72894844 가 하드코딩되어 있어 같은 현상이 재현됩니다.                                                                                                                            
  5. 백엔드 경로 식별자인 game_id(예: game_95ee4b56)는 UUID로 난수 생성되지만, 이 값은 브라우저의 RMMZ 엔진과 연결되지 않습니다. 엔진은 오직 $dataSystem.advanced.gameId 만 참조합니다.                                                                       
                                                                                                                                                                                                                                                              
  결과적으로 모든 프로젝트가 localStorage 에서 같은 키(rmmzsave.72894844.*)를 공유하게 되어 세이브가 교차 접근되었습니다.                                                                                                                                     
                                                                                                                                                                                                                                                              
  변경 사항                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                              
  1. 신규 프로젝트: 생성 시점에 고유 gameId 주입                                                                                                                                                                                                              
   
  app/backend/services/game_service.py                                                                                                                                                                                                                        
  - _copy_base_game 끝에 _randomize_system_game_id(game_id) 호출을 추가해, base_game 을 복사한 직후 System.json 의 advanced.gameId 를 1..2^31-1 범위의 암호학적 난수(secrets.randbelow) 로 덮어씁니다.
  - local 파일시스템과 S3 스토리지 백엔드 모두 지원하도록 _randomize_system_game_id / _s3_randomize_system_game_id 두 메서드로 분리.                                                                                                                          
                                                                                                                                    
  agent/generation/nodes/integrator.py                                                                                                                                                                                                                        
  - build_system_json_phase2 의 하드코딩된 "gameId": 72894844 를 secrets.randbelow(2**31 - 1) + 1 로 교체. AI 생성 프로젝트도 매번 고유한 gameId 를 갖습니다.                                                                                                 
                                                                                                                                                                                                                                                              
  2. 기존 프로젝트: 일회성 백필 스크립트                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                              
  scripts/backfill_system_game_id.py (신규)                                                                                                                                                                                                                   
  - 이미 배포된 환경에 존재하는 프로젝트들은 여전히 72894844 를 공유하므로, 이들을 일괄로 갱신하는 스크립트.
  - settings.STORAGE_BACKEND 값에 따라 local/S3 자동 감지.                                                                                                                                                                                                    
  - 안전을 위해 dry-run 기본. 실제 적용은 --apply 필요.           
  - --force 옵션으로 BASE_GAME_ID 가 아닌 값도 강제 갱신 가능.                                                                                                                                                                                                
                                                                                                                                                                                                                                                              
  # 먼저 dry-run 으로 대상 확인                                                                                                                                                                                                                               
  uv run python scripts/backfill_system_game_id.py                                                                                                                                                                                                            
                                                                                                                                                                                                                                                              
  # 확인 후 실제 적용                                                                                                                                                                                                                                         
  uv run python scripts/backfill_system_game_id.py --apply                                                                                                                                                                                                    
                                                                  
  검증

  - uv run ruff check / uv run pytest agent/tests/generation/test_integrator.py 모두 통과                                                                                                                                                                     
  - 로컬에서 _randomize_system_game_id 를 3회 호출한 결과 모두 서로 다른 고유값 생성 확인 (base 값 72894844 미포함)
  - 백필 스크립트 dry-run 실행해 대상 프로젝트 식별 동작 확인                                                                                                                                                                                                 
                                                                                                                                                                                                                                                              
  배포 가이드                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                              
  1. 이 PR 머지 후 서버 배포 진행                                                                                                                                                                                                                             
  2. 운영 환경에서 백필 스크립트 dry-run 실행해 영향 범위 확인    
  3. 문제 없으면 --apply 옵션으로 실제 백필 수행                                                                                                                                                                                                              
  4. 사용자 브라우저에 남아있는 과거 세이브는 키가 바뀌면서 자동으로 매칭되지 않게 되므로, 새 프로젝트에서 "이어하기" 가 더 이상 활성화되지 않습니다.                                                                                                         
                                                                                                                                                                                                                                                              
  테스트 체크리스트                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                              
  - 새 프로젝트 생성 후 data/System.json 의 advanced.gameId 가 72894844 가 아닌지 확인                                                                                                                                                                        
  - 서로 다른 두 프로젝트의 gameId 가 다른지 확인
  - 기존 세이브가 있는 상태에서 새 프로젝트 접속 시 "이어하기" 가 비활성화되는지 확인                                                                                                                                                                         
  - AI 생성 경로로 만든 프로젝트도 고유 gameId 를 갖는지 확인                                                                                                                                                                                                 
  - 백필 스크립트 dry-run → apply 흐름이 운영 데이터에서 정상 동작하는지 확인                                                                                                                                                                                 
  - S3 스토리지 모드에서도 동일하게 동작하는지 확인