### PR TITLE
docs: EC2 상태 변경 Discord 알림 가이드 및 Lambda/EventBridge 템플릿 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ RPG Maker MZ 등 **원 저작물·상표·에셋**에 대한 권리는 각 권�
 - [`docs/backend/logging.md`](docs/backend/logging.md) — 로깅
 - [`docs/deployment/deployment.md`](docs/deployment/deployment.md) — 배포(Vercel·EC2 등)
 - [`docs/deployment/ec2-host-monitor.md`](docs/deployment/ec2-host-monitor.md) — EC2 호스트 모니터링
+- [`docs/deployment/ec2-state-discord-alert.md`](docs/deployment/ec2-state-discord-alert.md) — EC2 중지/종료 상태 Discord 알림
 - [`docs/rpgmaker/structure.md`](docs/rpgmaker/structure.md) — RPG Maker 데이터 구조
 - [`docs/rpgmaker/tile_rendering.md`](docs/rpgmaker/tile_rendering.md) — 타일 렌더링
 - [`docs/rpgmaker/image_metadata.md`](docs/rpgmaker/image_metadata.md) — 이미지 메타데이터

--- a/docs/deployment/ec2-state-discord-alert.md
+++ b/docs/deployment/ec2-state-discord-alert.md
@@ -1,0 +1,117 @@
+# EC2 전원/상태 변경 알림 (EventBridge -> Lambda -> Discord)
+
+EC2 내부 스크립트(`ec2_host_monitor.sh`)는 인스턴스가 꺼지면 함께 멈춥니다.
+그래서 **인스턴스 종료/중지 알림은 AWS 이벤트 기반**으로 구성해야 합니다.
+
+이 문서는 다음 흐름을 설정합니다.
+
+```text
+EC2 상태 변경 이벤트 -> EventBridge 규칙 -> Lambda -> Discord 웹훅
+```
+
+---
+
+## 1) 준비물
+
+- Discord 웹훅 URL
+- 대상 EC2 인스턴스 ID (`i-...`)
+- AWS 콘솔 접근 권한 (EventBridge/Lambda/IAM)
+
+---
+
+## 2) Lambda 함수 만들기
+
+### 2-1. 코드 업로드
+
+저장소 파일을 Lambda 코드로 사용:
+
+- `scripts/aws/ec2_state_discord_lambda.py`
+
+핸들러:
+
+- `ec2_state_discord_lambda.lambda_handler`
+
+> 파일 이름을 그대로 올렸다면 핸들러 문자열도 위와 동일합니다.
+
+### 2-2. Lambda 환경 변수
+
+아래를 설정하세요.
+
+- `DISCORD_INFRA_WEBHOOK_URL` (권장, 기존 인프라 알림과 통일)
+- `TARGET_INSTANCE_ID` (선택, 특정 인스턴스만 필터링)
+- `TIMEZONE=Asia/Seoul` (선택)
+
+참고:
+
+- `DISCORD_INFRA_WEBHOOK_URL`가 없으면 `DISCORD_WEBHOOK_URL`를 fallback으로 사용합니다.
+
+### 2-3. Lambda Timeout
+
+- 기본 3초는 짧을 수 있어 **10초** 권장
+
+### 2-4. Lambda IAM 권한
+
+실행 역할에 다음 권한이 필요합니다.
+
+- `AWSLambdaBasicExecutionRole` (CloudWatch Logs)
+- `ec2:DescribeInstances` (EC2 Name tag 조회용)
+
+`ec2:DescribeInstances`가 없으면 인스턴스 이름이 `unknown`으로 표시됩니다.
+
+---
+
+## 3) EventBridge 규칙 만들기
+
+### 3-1. 이벤트 패턴
+
+아래 템플릿 파일을 사용하세요.
+
+- `scripts/aws/eventbridge_ec2_state_pattern.json`
+
+`i-REPLACE_WITH_YOUR_INSTANCE_ID`를 실제 ID로 바꿉니다.
+
+원하는 상태만 선택 가능:
+
+- 다운 감지 위주: `stopping`, `stopped`, `terminated`
+- 복구 감지도 필요: `running` 추가
+
+### 3-2. 타겟 연결
+
+EventBridge Rule Target을 위 Lambda로 연결합니다.
+
+---
+
+## 4) 테스트 순서
+
+1. EventBridge 규칙 저장
+2. EC2를 `Stop` 실행
+3. Discord 알림 수신 확인
+4. EC2 `Start` 후 `running` 알림 확인(패턴에 넣은 경우)
+
+---
+
+## 5) 운영 팁
+
+- 운영 서버만 감시하려면 `instance-id` 필터 유지
+- 여러 인스턴스를 감시하려면 `instance-id` 배열에 추가
+- 알림 스팸이 많으면 `running` 상태를 빼고 다운 이벤트만 유지
+
+---
+
+## 6) 자주 하는 질문
+
+### Q1. 기존 `ec2_host_monitor.sh`는 지워야 하나요?
+
+아니요. 역할이 다릅니다.
+
+- `ec2_host_monitor.sh`: **켜져 있는 서버의 디스크/부하** 감시
+- EventBridge/Lambda: **서버가 꺼졌는지(상태 변경)** 감시
+
+둘 다 함께 쓰는 것이 가장 안전합니다.
+
+### Q2. 앱이 죽었는데 EC2는 살아 있으면?
+
+이 구성만으로는 못 잡을 수 있습니다. 아래를 같이 권장합니다.
+
+- CloudWatch Alarm: `StatusCheckFailed`
+- 외부 Uptime 체크: `/health` 엔드포인트

--- a/scripts/aws/ec2_state_discord_lambda.py
+++ b/scripts/aws/ec2_state_discord_lambda.py
@@ -1,0 +1,109 @@
+"""
+EC2 상태 변경 이벤트를 Discord로 전송하는 Lambda 핸들러.
+
+권장 연결:
+EventBridge (EC2 state-change) -> Lambda -> Discord webhook
+
+환경 변수:
+- DISCORD_INFRA_WEBHOOK_URL (권장, 기존 인프라 알림과 이름 통일)
+- DISCORD_WEBHOOK_URL (fallback)
+- TARGET_INSTANCE_ID (선택: 특정 EC2만 알림)
+- TIMEZONE (선택: 기본 Asia/Seoul)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import boto3
+
+ec2 = boto3.client("ec2")
+
+
+def _webhook_url() -> str:
+    return (
+        os.getenv("DISCORD_INFRA_WEBHOOK_URL") or os.getenv("DISCORD_WEBHOOK_URL") or ""
+    ).strip()
+
+
+def _target_instance_id() -> str:
+    return (os.getenv("TARGET_INSTANCE_ID") or "").strip()
+
+
+def _timezone() -> str:
+    return (os.getenv("TIMEZONE") or "Asia/Seoul").strip()
+
+
+def _instance_name(instance_id: str) -> str:
+    try:
+        resp = ec2.describe_instances(InstanceIds=[instance_id])
+        reservations = resp.get("Reservations", [])
+        if not reservations:
+            return "unknown"
+        instance = reservations[0]["Instances"][0]
+        for tag in instance.get("Tags", []):
+            if tag.get("Key") == "Name":
+                return str(tag.get("Value") or "unnamed")
+        return "unnamed"
+    except Exception:
+        return "unknown"
+
+
+def _to_local_time(iso_utc: str) -> str:
+    # EventBridge time 예: 2026-04-17T03:10:27Z
+    dt_utc = datetime.fromisoformat(iso_utc.replace("Z", "+00:00")).astimezone(UTC)
+    try:
+        dt_local = dt_utc.astimezone(ZoneInfo(_timezone()))
+    except Exception:
+        dt_local = dt_utc
+    return dt_local.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def _send_discord(content: str) -> None:
+    url = _webhook_url()
+    if not url:
+        raise RuntimeError("DISCORD_INFRA_WEBHOOK_URL (or DISCORD_WEBHOOK_URL) is not set")
+
+    payload = {"content": content}
+    req = urllib.request.Request(
+        url=url,
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as res:
+        if not (200 <= res.status < 300):
+            raise RuntimeError(f"Discord webhook failed: HTTP {res.status}")
+
+
+def lambda_handler(event, context):
+    detail = event.get("detail", {})
+    instance_id = str(detail.get("instance-id", "unknown"))
+    state = str(detail.get("state", "unknown")).lower()
+
+    target_id = _target_instance_id()
+    if target_id and instance_id != target_id:
+        return {"ok": True, "skipped": "not target instance"}
+
+    instance_name = _instance_name(instance_id)
+    local_time = _to_local_time(str(event.get("time", datetime.now(UTC).isoformat())))
+    region = str(event.get("region", "unknown"))
+    account = str(event.get("account", "unknown"))
+
+    emoji = "🔴" if state in {"stopping", "stopped", "terminated"} else "🟢"
+
+    message = (
+        f"{emoji} **[Re:Verse EC2 상태 변경]**\n"
+        f"- 서버 이름: `{instance_name}`\n"
+        f"- 인스턴스 ID: `{instance_id}`\n"
+        f"- 상태: **`{state.upper()}`**\n"
+        f"- 시간: `{local_time}`\n"
+        f"- 리전: `{region}` / 계정: `{account}`"
+    )
+
+    _send_discord(message)
+    return {"ok": True, "instance_id": instance_id, "state": state}

--- a/scripts/aws/eventbridge_ec2_state_pattern.json
+++ b/scripts/aws/eventbridge_ec2_state_pattern.json
@@ -1,0 +1,8 @@
+{
+  "source": ["aws.ec2"],
+  "detail-type": ["EC2 Instance State-change Notification"],
+  "detail": {
+    "state": ["stopping", "stopped", "terminated", "running"],
+    "instance-id": ["i-REPLACE_WITH_YOUR_INSTANCE_ID"]
+  }
+}


### PR DESCRIPTION
## Summary

- EC2 인스턴스 상태 변경(중지/종료/재기동) 시 Discord 알림을 보낼 수 있도록 Lambda 템플릿을 추가했습니다.
- EventBridge 규칙에서 바로 사용할 수 있는 EC2 상태 변경 이벤트 패턴(JSON) 템플릿을 추가했습니다.
- 운영 문서 및 README 참고 링크를 업데이트해, 실제 설정 순서와 운영 시 주의사항(권한/대안 모니터링)을 정리했습니다.

## Changes

- `scripts/aws/ec2_state_discord_lambda.py`
  - EC2 state-change 이벤트를 받아 Discord 웹훅으로 알림 전송
  - `DISCORD_INFRA_WEBHOOK_URL` 우선 사용, `DISCORD_WEBHOOK_URL` fallback
  - `TARGET_INSTANCE_ID` 필터, `TIMEZONE`(기본 `Asia/Seoul`) 지원
  - `ec2:DescribeInstances` 기반 Name 태그 조회 지원
- `scripts/aws/eventbridge_ec2_state_pattern.json`
  - `stopping`, `stopped`, `terminated`, `running` 상태 이벤트 패턴 템플릿 추가
- `docs/deployment/ec2-state-discord-alert.md`
  - EventBridge -> Lambda -> Discord 구성 절차 문서화
  - IAM 권한, 환경변수, Timeout, 테스트 절차, FAQ 정리
- `README.md`
  - EC2 상태 변경 Discord 알림 문서 링크 추가

## Why

- 기존 EC2 내부 스크립트 기반 모니터링은 인스턴스가 꺼지면 함께 멈춰 “전원 종료/상태 변경” 알림을 보장하지 못했습니다.
- AWS 이벤트 기반 템플릿과 문서를 함께 제공해, 권한이 있는 환경에서는 즉시 표준 방식으로 구축할 수 있게 했습니다.
- 권한 제한 계정에서는 외부 모니터링(UptimeRobot 등)으로 대체할 수 있도록 운영 선택지를 명확히 했습니다.

## Test Plan

- [ ] Lambda 함수 생성 후 `scripts/aws/ec2_state_discord_lambda.py` 코드 배포
- [ ] Lambda 환경변수 설정
  - [ ] `DISCORD_INFRA_WEBHOOK_URL`
  - [ ] `TARGET_INSTANCE_ID` (선택)
  - [ ] `TIMEZONE=Asia/Seoul` (선택)
- [ ] Lambda 실행 역할에 `AWSLambdaBasicExecutionRole`, `ec2:DescribeInstances` 권한 확인
- [ ] EventBridge 규칙 생성 시 `scripts/aws/eventbridge_ec2_state_pattern.json` 적용
- [ ] EC2 Stop/Start 테스트 후 Discord 알림 수신 확인
- [ ] (권한 제한 계정) EventBridge 사용 불가 시 UptimeRobot으로 `/health` 모니터링 대체 구성 확인