### PR TITLE
fix: Actors.json 중복 생성 버그 수정 (#157)

### DIFF
--- a/agent/generation/nodes/asset_generator.py
+++ b/agent/generation/nodes/asset_generator.py
@@ -1714,8 +1714,12 @@ async def generate_actors(
         ActorListOutput,
         await invoke_llm(messages, structured_output=ActorListOutput, temperature=_TEMPERATURE),
     )
+    valid_actor_ids = set(id_table.actors.values())
     output: list[Any] = [None]
     for actor in sorted(result.items, key=lambda a: a.id):
+        if actor.id not in valid_actor_ids:
+            logger.warning("LLM이 유효하지 않은 actor id=%d 생성 → 무시", actor.id)
+            continue
         d = actor.model_dump()
 
         # characterName 검증


### PR DESCRIPTION
## 변경 사항
`generate_actors()`에서 LLM이 유효하지 않은 actor ID를 생성할 경우
`id_table.actors` 기반으로 필터링하도록 수정

## 원인
LLM이 스프라이트 시트 예시(Actor1, SF_Actor1)를 참고해 동일 캐릭터를 두 세트로 생성하는 경우가 있었음 → 3명 설정 시 6명(id 1~6)이 출력되는 버그 발생

 ## 수정 파일
 - `agent/generation/nodes/asset_generator.py`
 
 ## 테스트
 - [ ] 캐릭터 3명 설정 후 게임 생성 → Actors.json 항목이 3개인지 확인
 
 Closes #157